### PR TITLE
Fix for like in cql2_json backend, add support for upper function

### DIFF
--- a/pygeofilter/backends/cql2_json/evaluate.py
+++ b/pygeofilter/backends/cql2_json/evaluate.py
@@ -72,7 +72,7 @@ class CQL2Evaluator(Evaluator):
 
     @handle(ast.Like)
     def like(self, node, *subargs):
-        return {"op": "like", "args": [node.lhs, node.pattern]}
+        return {"op": "like:, "args": [subargs[0], node.pattern]}
 
     @handle(ast.IsNull)
     def isnull(self, node, arg):
@@ -83,6 +83,8 @@ class CQL2Evaluator(Evaluator):
         name = node.name.lower()
         if name == "lower":
             ret = {"lower": args[0]}
+        elif name == "upper":
+            ret = {"upper": args[0]}
         else:
             ret = {"function": name, "args": [*args]}
         return ret

--- a/pygeofilter/backends/cql2_json/evaluate.py
+++ b/pygeofilter/backends/cql2_json/evaluate.py
@@ -72,7 +72,7 @@ class CQL2Evaluator(Evaluator):
 
     @handle(ast.Like)
     def like(self, node, *subargs):
-        return {"op": "like:, "args": [subargs[0], node.pattern]}
+        return {"op": "like", "args": [subargs[0], node.pattern]}
 
     @handle(ast.IsNull)
     def isnull(self, node, arg):


### PR DESCRIPTION
Fix for LIKE operator in CQL2-JSON backend. LIKE was returning the property as just the string with the name of the property and not as an attribute node.

Adds support for the UPPER function to CQL2-JSON backend.