### PR TITLE
Update to use WKT vs WKB

### DIFF
--- a/pygeofilter/backends/sql/evaluate.py
+++ b/pygeofilter/backends/sql/evaluate.py
@@ -149,8 +149,8 @@ class SQLEvaluator(Evaluator):
 
     @handle(values.Geometry)
     def geometry(self, node: values.Geometry):
-        wkb_hex = shapely.geometry.shape(node).wkb_hex
-        return f"ST_GeomFromWKB(x'{wkb_hex}')"
+        wkt = shapely.geometry.shape(node).wkt
+        return f"ST_SetSRID(ST_GeomFromText('{wkt}'),4326)"
 
     @handle(values.Envelope)
     def envelope(self, node: values.Envelope):


### PR DESCRIPTION
Currently the geometry is converted to WKB, but this does not convert correctly when executing the sql statement. By using WKT, we no longer see this issue occur.

Example: `INTERSECTS(geom, POINT(-89.004202 40.503501))`

Converts to: `ST_Intersects("geom",ST_GeomFromWKB(x'0101000000FB2477D8444056C06C4084B872404440'))`

Running the following SQL: 

`SELECT ST_GeomFromWKB(x'0101000000FB2477D8444056C06C4084B872404440')`

You receive the following error: 

`ERROR:  function st_geomfromwkb(bit) does not exist
LINE 1: SELECT ST_GeomFromWKB(x'0101000000FB2477D8444056C06C4084B872...
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
SQL state: 42883
Character: 8`

After converting to use `ST_GeomFromText` this issue no longer occurs.