### PR TITLE
Fix pygeoif to version 7

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ pyproj
 rtree
 pygml
 dateparser
-pygeoif
+pygeoif==0.7
 lark
 elasticsearch
 elasticsearch-dsl


### PR DESCRIPTION
Current bug:
```
ImportError: cannot import name 'as_shape' from 'pygeoif.geometry' (/usr/local/lib/python3.8/dist-packages/pygeoif/geometry.py)
```
This PR provides interim fix, by forcing pygeoif==0.7  while waiting for https://github.com/geopython/pygeofilter/pull/56 to be approved. 