### PR TITLE
Fixes CQL2 JSON "IN LIST" evaluation

### DIFF
--- a/pygeofilter/backends/cql2_json/evaluate.py
+++ b/pygeofilter/backends/cql2_json/evaluate.py
@@ -91,7 +91,7 @@ class CQL2Evaluator(Evaluator):
 
     @handle(ast.In)
     def in_(self, node, lhs, *options):
-        return {"in": {"value": lhs, "list": options}}
+        return {"op": "in", "args": [lhs, options]}
 
     @handle(ast.Attribute)
     def attribute(self, node: ast.Attribute):


### PR DESCRIPTION
The IN LIST evaluator for the CQL2 JSON backend used the previous CQL syntax for specifying value/list arguments to the operator. Updates to use the CQL op/args format.

Before:

```python
ast = parse_c("collection = 'sentinel-2' and s2:mgrs_tile in ('20LKP','20LNP')")
>>> to_cql2(ast)
'{"op": "and", "args": [{"op": "=", "args": [{"property": "collection"}, "sentinel-2"]}, {"in": {"value": {"property": "s2:mgrs_tile"}, "list": ["20LKP", "20LNP"]}}]}'
```

After

```python
>>> ast = parse_c("collection = 'sentinel-2' and s2:mgrs_tile in ('20LKP','20LNP')")
>>> to_cql2(ast)
'{"op": "and", "args": [{"op": "=", "args": [{"property": "collection"}, "sentinel-2"]}, {"op": "in", "args": [{"property": "s2:mgrs_tile"}, ["20LKP", "20LNP"]]}]}'
```