### PR TITLE
add support for qualified named attribute in ecql

### DIFF
--- a/pygeofilter/parsers/ecql/grammar.lark
+++ b/pygeofilter/parsers/ecql/grammar.lark
@@ -90,6 +90,7 @@
 
 attribute: NAME
          | DOUBLE_QUOTED
+         | QUALIFIED_NAME
 
 ?literal: number
         | BOOLEAN
@@ -112,6 +113,8 @@ BOOLEAN: ( "TRUE" | "FALSE" )
 
 DOUBLE_QUOTED: "\"" /.*?/ "\""
 SINGLE_QUOTED: "'" /.*?/ "'"
+
+QUALIFIED_NAME: NAME ":" NAME
 
 %import .wkt.ewkt_geometry
 %import .iso8601.DATETIME

--- a/tests/parsers/ecql/test_parser.py
+++ b/tests/parsers/ecql/test_parser.py
@@ -34,6 +34,14 @@ from pygeofilter import ast, values
 from pygeofilter.parsers.ecql import parse
 
 
+def test_namespace_attribute_eq_literal():
+    result = parse("ns:attr = 'A'")
+    assert result == ast.Equal(
+        ast.Attribute("ns:attr"),
+        "A",
+    )
+
+
 def test_attribute_eq_literal():
     result = parse("attr = 'A'")
     assert result == ast.Equal(


### PR DESCRIPTION
add support for qualified named attribute in ecql like `dc:title LIKE '%huhu%'` 

fixes #22 