### PR TITLE
New backend for Oracle SQL

### DIFF
--- a/pygeofilter/backends/oraclesql/__init__.py
+++ b/pygeofilter/backends/oraclesql/__init__.py
@@ -1,0 +1,3 @@
+from .evaluate import to_sql_where, to_sql_where_with_binds
+
+__all__ = ["to_sql_where","to_sql_where_with_binds"]

--- a/pygeofilter/backends/oraclesql/__init__.py
+++ b/pygeofilter/backends/oraclesql/__init__.py
@@ -1,3 +1,3 @@
-from .evaluate import to_sql_where, to_sql_where_with_binds
+from .evaluate import to_sql_where, to_sql_where_with_bind_variables
 
-__all__ = ["to_sql_where", "to_sql_where_with_binds"]
+__all__ = ["to_sql_where", "to_sql_where_with_bind_variables"]

--- a/pygeofilter/backends/oraclesql/__init__.py
+++ b/pygeofilter/backends/oraclesql/__init__.py
@@ -1,3 +1,3 @@
 from .evaluate import to_sql_where, to_sql_where_with_binds
 
-__all__ = ["to_sql_where","to_sql_where_with_binds"]
+__all__ = ["to_sql_where", "to_sql_where_with_binds"]

--- a/pygeofilter/backends/oraclesql/evaluate.py
+++ b/pygeofilter/backends/oraclesql/evaluate.py
@@ -1,0 +1,209 @@
+# ------------------------------------------------------------------------------
+#
+# Project: pygeofilter <https://github.com/geopython/pygeofilter>
+# Authors: Andreas Kosubek <andreas.kosubek@ama.gv.at>
+#
+# ------------------------------------------------------------------------------
+# Copyright (C) 2023 Agrar Markt Austria
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ------------------------------------------------------------------------------
+
+from typing import Dict, Optional
+
+import shapely.geometry
+
+from ... import ast, values
+from ..evaluator import Evaluator, handle
+
+COMPARISON_OP_MAP = {
+    ast.ComparisonOp.EQ: "=",
+    ast.ComparisonOp.NE: "<>",
+    ast.ComparisonOp.LT: "<",
+    ast.ComparisonOp.LE: "<=",
+    ast.ComparisonOp.GT: ">",
+    ast.ComparisonOp.GE: ">=",
+}
+
+
+ARITHMETIC_OP_MAP = {
+    ast.ArithmeticOp.ADD: "+",
+    ast.ArithmeticOp.SUB: "-",
+    ast.ArithmeticOp.MUL: "*",
+    ast.ArithmeticOp.DIV: "/",
+}
+
+SPATIAL_COMPARISON_OP_MAP = {
+    ast.SpatialComparisonOp.INTERSECTS: "ANYINTERACT",
+    ast.SpatialComparisonOp.DISJOINT: "DISJOINT",
+    ast.SpatialComparisonOp.CONTAINS: "CONTAINS",
+    ast.SpatialComparisonOp.WITHIN: "INSIDE",
+    ast.SpatialComparisonOp.TOUCHES: "TOUCH",
+    ast.SpatialComparisonOp.CROSSES: "OVERLAPBDYDISJOINT",
+    ast.SpatialComparisonOp.OVERLAPS: "OVERLAPBDYINTERSECT",
+    ast.SpatialComparisonOp.EQUALS: "EQUAL",
+}
+
+WITH_BINDS = False
+
+BIND_VARIABLES = {}
+
+
+class OracleSQLEvaluator(Evaluator):
+    def __init__(
+        self, attribute_map: Dict[str, str], function_map: Dict[str, str]
+    ):
+        self.attribute_map = attribute_map
+        self.function_map = function_map
+
+    @handle(ast.Not)
+    def not_(self, node, sub):
+        return f"NOT {sub}"
+
+    @handle(ast.And, ast.Or)
+    def combination(self, node, lhs, rhs):
+        return f"({lhs} {node.op.value} {rhs})"
+
+    @handle(ast.Comparison, subclasses=True)
+    def comparison(self, node, lhs, rhs):
+        if WITH_BINDS:
+            BIND_VARIABLES[f"{lhs}"] = rhs
+            sql = f"({lhs} {COMPARISON_OP_MAP[node.op]} :{lhs})"
+        else:
+            sql = f"({lhs} {COMPARISON_OP_MAP[node.op]} {rhs})"
+        return sql
+
+    @handle(ast.Between)
+    def between(self, node, lhs, low, high):
+        if WITH_BINDS:
+            BIND_VARIABLES[f"{lhs}_high"] = high
+            BIND_VARIABLES[f"{lhs}_low"] = low
+            sql = f"({lhs} {'NOT ' if node.not_ else ''}BETWEEN :{lhs}_low AND :{lhs}_high)"
+        else:
+            sql = f"({lhs} {'NOT ' if node.not_ else ''}BETWEEN {low} AND {high})"
+        return sql
+
+    @handle(ast.Like)
+    def like(self, node, lhs):
+        pattern = node.pattern
+        if node.wildcard != "%":
+            # TODO: not preceded by escapechar
+            pattern = pattern.replace(node.wildcard, "%")
+        if node.singlechar != "_":
+            # TODO: not preceded by escapechar
+            pattern = pattern.replace(node.singlechar, "_")
+
+        if WITH_BINDS:
+            BIND_VARIABLES[f"{lhs}"] = pattern
+            sql = f"{lhs} {'NOT ' if node.not_ else ''}LIKE "
+            sql += f":{lhs} ESCAPE '{node.escapechar}'"
+
+        else:
+            sql = f"{lhs} {'NOT ' if node.not_ else ''}LIKE "
+            sql += f"'{pattern}' ESCAPE '{node.escapechar}'"
+
+        # TODO: handle node.nocase
+        return sql
+
+    @handle(ast.In)
+    def in_(self, node, lhs, *options):
+        return f"{lhs} {'NOT ' if node.not_ else ''}IN ({', '.join(options)})"
+
+    @handle(ast.IsNull)
+    def null(self, node, lhs):
+        return f"{lhs} IS {'NOT ' if node.not_ else ''}NULL"
+
+    @handle(ast.SpatialComparisonPredicate, subclasses=True)
+    def spatial_operation(self, node, lhs, rhs):
+        param = f"mask={SPATIAL_COMPARISON_OP_MAP[node.op]}"
+        func = f"SDO_RELATE({lhs}, {rhs}, '{param}') = 'TRUE'"
+        return func
+
+    @handle(ast.BBox)
+    def bbox(self, node, lhs):
+        bbox = "SDO_GEOMETRY()"
+        param = f"mask={ast.SpatialComparisonOp.INTERSECTS}"
+        func = f"SDO_RELATE({lhs}, {bbox}, '{param}') = 'TRUE'"
+        return func
+
+    @handle(ast.Attribute)
+    def attribute(self, node: ast.Attribute):
+        return f"{self.attribute_map[node.name]}"
+
+    @handle(ast.Arithmetic, subclasses=True)
+    def arithmetic(self, node: ast.Arithmetic, lhs, rhs):
+        op = ARITHMETIC_OP_MAP[node.op]
+        return f"({lhs} {op} {rhs})"
+
+    @handle(ast.Function)
+    def function(self, node, *arguments):
+        func = self.function_map[node.name]
+        return f"{func}({','.join(arguments)})"
+
+    @handle(*values.LITERALS)
+    def literal(self, node):
+        if isinstance(node, str):
+            return f"'{node}'"
+        else:
+            return node
+
+    @handle(values.Geometry)
+    def geometry(self, node: values.Geometry):
+        wkb_hex = shapely.geometry.shape(node).wkb_hex
+        if WITH_BINDS:
+            BIND_VARIABLES["wkb"] = wkb_hex
+            sql = "SDO_UTIL.FROM_WKBGEOMETRY(:wkb)"
+        else:
+            sql = f"SDO_UTIL.FROM_WKBGEOMETRY('{wkb_hex}')"
+        return sql
+
+    @handle(values.Envelope)
+    def envelope(self, node: values.Envelope):
+        wkb_hex = shapely.geometry.box(
+            node.x1, node.y1, node.x2, node.y2
+        ).wkb_hex
+        if WITH_BINDS:
+            BIND_VARIABLES["wkb"] = wkb_hex
+            sql = "SDO_UTIL.FROM_WKBGEOMETRY(:wkb)"
+        else:
+            sql = f"SDO_UTIL.FROM_WKBGEOMETRY('{wkb_hex}')"
+        return sql
+
+
+def to_sql_where(
+    root: ast.Node,
+    field_mapping: Dict[str, str],
+    function_map: Optional[Dict[str, str]] = None,
+) -> str:
+    global WITH_BINDS
+    WITH_BINDS = False
+    return OracleSQLEvaluator(field_mapping, function_map or {}).evaluate(root)
+
+
+def to_sql_where_with_binds(
+    root: ast.Node,
+    field_mapping: Dict[str, str],
+    function_map: Optional[Dict[str, str]] = None,
+) -> str:
+    orcle = OracleSQLEvaluator(field_mapping, function_map or {})
+    global WITH_BINDS
+    WITH_BINDS = True
+    global BIND_VARIABLES
+    BIND_VARIABLES = {}
+    return orcle.evaluate(root), BIND_VARIABLES

--- a/tests/backends/oraclesql/test_evaluate.py
+++ b/tests/backends/oraclesql/test_evaluate.py
@@ -1,0 +1,95 @@
+import pytest
+
+from pygeofilter.backends.oraclesql import (
+    to_sql_where,
+    to_sql_where_with_binds,
+)
+from pygeofilter.parsers.ecql import parse
+
+FIELD_MAPPING = {
+    "str_attr": "str_attr",
+    "maybe_str_attr": "maybe_str_attr",
+    "int_attr": "int_attr",
+    "float_attr": "float_attr",
+    "date_attr": "date_attr",
+    "datetime_attr": "datetime_attr",
+    "point_attr": "geometry_attr",
+}
+
+FUNCTION_MAP = {}
+
+
+def test_between():
+    where = to_sql_where(
+        parse("int_attr NOT BETWEEN 4 AND 6"), FIELD_MAPPING, FUNCTION_MAP
+    )
+    assert where == "(int_attr NOT BETWEEN 4 AND 6)"
+
+
+def test_between_with_binds():
+    where, binds = to_sql_where_with_binds(
+        parse("int_attr NOT BETWEEN 4 AND 6"), FIELD_MAPPING, FUNCTION_MAP
+    )
+    assert where == "(int_attr NOT BETWEEN :int_attr_low AND :int_attr_high)"
+    assert binds == {"int_attr_low": 4, "int_attr_high": 6}
+
+
+def test_like():
+    where = to_sql_where(
+        parse("str_attr LIKE 'foo%'"), FIELD_MAPPING, FUNCTION_MAP
+    )
+    assert where == "str_attr LIKE 'foo%' ESCAPE '\\'"
+
+
+def test_like_with_binds():
+    where, binds = to_sql_where_with_binds(
+        parse("str_attr LIKE 'foo%'"), FIELD_MAPPING, FUNCTION_MAP
+    )
+    assert where == "str_attr LIKE :str_attr ESCAPE '\\'"
+    assert binds == {"str_attr": "foo%"}
+
+
+def test_combination():
+    where = to_sql_where(
+        parse("int_attr = 5 AND float_attr < 6.0"), FIELD_MAPPING, FUNCTION_MAP
+    )
+    assert where == "((int_attr = 5) AND (float_attr < 6.0))"
+
+
+def test_combination_with_binds():
+    where, binds = to_sql_where_with_binds(
+        parse("int_attr = 5 AND float_attr < 6.0"), FIELD_MAPPING, FUNCTION_MAP
+    )
+    assert where == "((int_attr = :int_attr) AND (float_attr < :float_attr))"
+    assert binds == {"int_attr": 5, "float_attr": 6.0}
+
+
+def test_spatial():
+    where = to_sql_where(
+        parse("INTERSECTS(point_attr, ENVELOPE (0 1 0 1))"),
+        FIELD_MAPPING,
+        FUNCTION_MAP,
+    )
+    wkb = "01030000000100000005000000000000000000F03F0000000000000000000000000000"
+    wkb += "F03F000000000000F03F0000000000000000000000000000F03F000000000000000000"
+    wkb += "00000000000000000000000000F03F0000000000000000"
+    assert (
+        where
+        == f"SDO_RELATE(geometry_attr, SDO_UTIL.FROM_WKBGEOMETRY('{wkb}'), 'mask=ANYINTERACT') = 'TRUE'"
+    )
+
+
+def test_spatial_with_binds():
+    where, binds = to_sql_where_with_binds(
+        parse("INTERSECTS(point_attr, ENVELOPE (0 1 0 1))"),
+        FIELD_MAPPING,
+        FUNCTION_MAP,
+    )
+    wkb = "01030000000100000005000000000000000000F03F0000000000000000000000000000"
+    wkb += "F03F000000000000F03F0000000000000000000000000000F03F000000000000000000"
+    wkb += "00000000000000000000000000F03F0000000000000000"
+    assert (
+        where
+        == "SDO_RELATE(geometry_attr, SDO_UTIL.FROM_WKBGEOMETRY(:wkb), 'mask=ANYINTERACT') = 'TRUE'"
+    )
+    assert binds == {"wkb": wkb}

--- a/tests/backends/oraclesql/test_evaluate.py
+++ b/tests/backends/oraclesql/test_evaluate.py
@@ -1,6 +1,6 @@
 from pygeofilter.backends.oraclesql import (
     to_sql_where,
-    to_sql_where_with_binds,
+    to_sql_where_with_bind_variables,
 )
 from pygeofilter.parsers.ecql import parse
 
@@ -24,13 +24,13 @@ def test_between():
 
 
 def test_between_with_binds():
-    where, binds = to_sql_where_with_binds(
+    where, binds = to_sql_where_with_bind_variables(
         parse("int_attr NOT BETWEEN 4 AND 6"),
         FIELD_MAPPING,
         FUNCTION_MAP
     )
-    assert where == "(int_attr NOT BETWEEN :int_attr_low AND :int_attr_high)"
-    assert binds == {"int_attr_low": 4, "int_attr_high": 6}
+    assert where == "(int_attr NOT BETWEEN :int_attr_low_0 AND :int_attr_high_0)"
+    assert binds == {"int_attr_low_0": 4, "int_attr_high_0": 6}
 
 
 def test_like():
@@ -43,13 +43,13 @@ def test_like():
 
 
 def test_like_with_binds():
-    where, binds = to_sql_where_with_binds(
+    where, binds = to_sql_where_with_bind_variables(
         parse("str_attr LIKE 'foo%'"),
         FIELD_MAPPING,
         FUNCTION_MAP
     )
-    assert where == "str_attr LIKE :str_attr ESCAPE '\\'"
-    assert binds == {"str_attr": "foo%"}
+    assert where == "str_attr LIKE :str_attr_0 ESCAPE '\\'"
+    assert binds == {"str_attr_0": "foo%"}
 
 
 def test_combination():
@@ -62,13 +62,13 @@ def test_combination():
 
 
 def test_combination_with_binds():
-    where, binds = to_sql_where_with_binds(
+    where, binds = to_sql_where_with_bind_variables(
         parse("int_attr = 5 AND float_attr < 6.0"),
         FIELD_MAPPING,
         FUNCTION_MAP
     )
-    assert where == "((int_attr = :int_attr) AND (float_attr < :float_attr))"
-    assert binds == {"int_attr": 5, "float_attr": 6.0}
+    assert where == "((int_attr = :int_attr_0) AND (float_attr < :float_attr_1))"
+    assert binds == {"int_attr_0": 5, "float_attr_1": 6.0}
 
 
 def test_spatial():
@@ -89,7 +89,7 @@ def test_spatial():
 
 
 def test_spatial_with_binds():
-    where, binds = to_sql_where_with_binds(
+    where, binds = to_sql_where_with_bind_variables(
         parse("INTERSECTS(point_attr, ENVELOPE (0 1 0 1))"),
         FIELD_MAPPING,
         FUNCTION_MAP,
@@ -100,10 +100,10 @@ def test_spatial_with_binds():
     )
     assert where == (
         "SDO_RELATE(geometry_attr, "
-        "SDO_UTIL.FROM_JSON(geometry => :geo_json, srid => :srid), "
+        "SDO_UTIL.FROM_JSON(geometry => :geo_json_0, srid => :srid_0), "
         "'mask=ANYINTERACT') = 'TRUE'"
     )
-    assert binds == {"geo_json": geo_json, "srid": 4326}
+    assert binds == {"geo_json_0": geo_json, "srid_0": 4326}
 
 
 def test_bbox():
@@ -128,7 +128,7 @@ def test_bbox():
 
 
 def test_bbox_with_binds():
-    where, binds = to_sql_where_with_binds(
+    where, binds = to_sql_where_with_bind_variables(
         parse("BBOX(point_attr,-140.99778,41.6751050889,-52.6480987209,83.23324)"),
         FIELD_MAPPING,
         FUNCTION_MAP,
@@ -143,7 +143,7 @@ def test_bbox_with_binds():
     )
     assert where == (
         "SDO_RELATE(geometry_attr, "
-        "SDO_UTIL.FROM_JSON(geometry => :geo_json, srid => :srid), "
+        "SDO_UTIL.FROM_JSON(geometry => :geo_json_0, srid => :srid_0), "
         "'mask=ANYINTERACT') = 'TRUE'"
     )
-    assert binds == {"geo_json": geo_json, "srid": 4326}
+    assert binds == {"geo_json_0": geo_json, "srid_0": 4326}

--- a/tests/backends/oraclesql/test_evaluate.py
+++ b/tests/backends/oraclesql/test_evaluate.py
@@ -1,5 +1,3 @@
-import pytest
-
 from pygeofilter.backends.oraclesql import (
     to_sql_where,
     to_sql_where_with_binds,
@@ -8,11 +6,8 @@ from pygeofilter.parsers.ecql import parse
 
 FIELD_MAPPING = {
     "str_attr": "str_attr",
-    "maybe_str_attr": "maybe_str_attr",
     "int_attr": "int_attr",
     "float_attr": "float_attr",
-    "date_attr": "date_attr",
-    "datetime_attr": "datetime_attr",
     "point_attr": "geometry_attr",
 }
 
@@ -21,14 +16,18 @@ FUNCTION_MAP = {}
 
 def test_between():
     where = to_sql_where(
-        parse("int_attr NOT BETWEEN 4 AND 6"), FIELD_MAPPING, FUNCTION_MAP
+        parse("int_attr NOT BETWEEN 4 AND 6"),
+        FIELD_MAPPING,
+        FUNCTION_MAP
     )
     assert where == "(int_attr NOT BETWEEN 4 AND 6)"
 
 
 def test_between_with_binds():
     where, binds = to_sql_where_with_binds(
-        parse("int_attr NOT BETWEEN 4 AND 6"), FIELD_MAPPING, FUNCTION_MAP
+        parse("int_attr NOT BETWEEN 4 AND 6"),
+        FIELD_MAPPING,
+        FUNCTION_MAP
     )
     assert where == "(int_attr NOT BETWEEN :int_attr_low AND :int_attr_high)"
     assert binds == {"int_attr_low": 4, "int_attr_high": 6}
@@ -36,14 +35,18 @@ def test_between_with_binds():
 
 def test_like():
     where = to_sql_where(
-        parse("str_attr LIKE 'foo%'"), FIELD_MAPPING, FUNCTION_MAP
+        parse("str_attr LIKE 'foo%'"),
+        FIELD_MAPPING,
+        FUNCTION_MAP
     )
     assert where == "str_attr LIKE 'foo%' ESCAPE '\\'"
 
 
 def test_like_with_binds():
     where, binds = to_sql_where_with_binds(
-        parse("str_attr LIKE 'foo%'"), FIELD_MAPPING, FUNCTION_MAP
+        parse("str_attr LIKE 'foo%'"),
+        FIELD_MAPPING,
+        FUNCTION_MAP
     )
     assert where == "str_attr LIKE :str_attr ESCAPE '\\'"
     assert binds == {"str_attr": "foo%"}
@@ -51,14 +54,18 @@ def test_like_with_binds():
 
 def test_combination():
     where = to_sql_where(
-        parse("int_attr = 5 AND float_attr < 6.0"), FIELD_MAPPING, FUNCTION_MAP
+        parse("int_attr = 5 AND float_attr < 6.0"),
+        FIELD_MAPPING,
+        FUNCTION_MAP
     )
     assert where == "((int_attr = 5) AND (float_attr < 6.0))"
 
 
 def test_combination_with_binds():
     where, binds = to_sql_where_with_binds(
-        parse("int_attr = 5 AND float_attr < 6.0"), FIELD_MAPPING, FUNCTION_MAP
+        parse("int_attr = 5 AND float_attr < 6.0"),
+        FIELD_MAPPING,
+        FUNCTION_MAP
     )
     assert where == "((int_attr = :int_attr) AND (float_attr < :float_attr))"
     assert binds == {"int_attr": 5, "float_attr": 6.0}
@@ -70,12 +77,14 @@ def test_spatial():
         FIELD_MAPPING,
         FUNCTION_MAP,
     )
-    wkb = "01030000000100000005000000000000000000F03F0000000000000000000000000000"
-    wkb += "F03F000000000000F03F0000000000000000000000000000F03F000000000000000000"
-    wkb += "00000000000000000000000000F03F0000000000000000"
-    assert (
-        where
-        == f"SDO_RELATE(geometry_attr, SDO_UTIL.FROM_WKBGEOMETRY('{wkb}'), 'mask=ANYINTERACT') = 'TRUE'"
+    geo_json = (
+        "{\"type\": \"Polygon\", "
+        "\"coordinates\": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}"
+    )
+    assert where == (
+        "SDO_RELATE(geometry_attr, "
+        f"SDO_UTIL.FROM_JSON(geometry => '{geo_json}', srid => 4326), "
+        "'mask=ANYINTERACT') = 'TRUE'"
     )
 
 
@@ -85,11 +94,56 @@ def test_spatial_with_binds():
         FIELD_MAPPING,
         FUNCTION_MAP,
     )
-    wkb = "01030000000100000005000000000000000000F03F0000000000000000000000000000"
-    wkb += "F03F000000000000F03F0000000000000000000000000000F03F000000000000000000"
-    wkb += "00000000000000000000000000F03F0000000000000000"
-    assert (
-        where
-        == "SDO_RELATE(geometry_attr, SDO_UTIL.FROM_WKBGEOMETRY(:wkb), 'mask=ANYINTERACT') = 'TRUE'"
+    geo_json = (
+        "{\"type\": \"Polygon\", "
+        "\"coordinates\": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}"
     )
-    assert binds == {"wkb": wkb}
+    assert where == (
+        "SDO_RELATE(geometry_attr, "
+        "SDO_UTIL.FROM_JSON(geometry => :geo_json, srid => :srid), "
+        "'mask=ANYINTERACT') = 'TRUE'"
+    )
+    assert binds == {"geo_json": geo_json, "srid": 4326}
+
+
+def test_bbox():
+    where = to_sql_where(
+        parse("BBOX(point_attr,-140.99778,41.6751050889,-52.6480987209,83.23324)"),
+        FIELD_MAPPING,
+        FUNCTION_MAP,
+    )
+    geo_json = (
+        "{\"type\": \"Polygon\", \"coordinates\": [["
+        "[-140.99778, 41.6751050889], "
+        "[-140.99778, 83.23324], "
+        "[-52.6480987209, 83.23324], "
+        "[-52.6480987209, 41.6751050889], "
+        "[-140.99778, 41.6751050889]]]}"
+    )
+    assert where == (
+        "SDO_RELATE(geometry_attr, "
+        f"SDO_UTIL.FROM_JSON(geometry => '{geo_json}', srid => 4326), "
+        "'mask=ANYINTERACT') = 'TRUE'"
+    )
+
+
+def test_bbox_with_binds():
+    where, binds = to_sql_where_with_binds(
+        parse("BBOX(point_attr,-140.99778,41.6751050889,-52.6480987209,83.23324)"),
+        FIELD_MAPPING,
+        FUNCTION_MAP,
+    )
+    geo_json = (
+        "{\"type\": \"Polygon\", \"coordinates\": [["
+        "[-140.99778, 41.6751050889], "
+        "[-140.99778, 83.23324], "
+        "[-52.6480987209, 83.23324], "
+        "[-52.6480987209, 41.6751050889], "
+        "[-140.99778, 41.6751050889]]]}"
+    )
+    assert where == (
+        "SDO_RELATE(geometry_attr, "
+        "SDO_UTIL.FROM_JSON(geometry => :geo_json, srid => :srid), "
+        "'mask=ANYINTERACT') = 'TRUE'"
+    )
+    assert binds == {"geo_json": geo_json, "srid": 4326}

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -31,7 +31,7 @@ class Record(Base):
             geometry_type="MULTIPOLYGON",
             srid=4326,
             spatial_index=False,
-            management=True,
+            # management=True,
         )
     )
     float_attribute = Column(Float)


### PR DESCRIPTION
For the implementation of the “OGC API – Features – Part 3: Filtering” in the Pygeoapi Oracle Provider, I expanded the geofilter to include support for Oracle. The Oracle backend also supports the use of bind variables.

Since the unit tests failed, I adapted the SQLAlchemy test.