### PR TITLE
Removed management parameter from definition of model in sqlalchemy tests

### DIFF
--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -31,7 +31,6 @@ class Record(Base):
             geometry_type="MULTIPOLYGON",
             srid=4326,
             spatial_index=False,
-            management=True,
         )
     )
     float_attribute = Column(Float)


### PR DESCRIPTION
This PR simply removes the usage of the `management` argument in the definition of sqlalchemy tests.

This follows the discussion in #86 and is inline with changes in upstream geoalchemy, as per geoalchemy/geoalchemy2#415

- fixes #86 