### PR TITLE
Refactored sqlalchemy-related parsing of geometry

### DIFF
--- a/pygeofilter/backends/sqlalchemy/filters.py
+++ b/pygeofilter/backends/sqlalchemy/filters.py
@@ -6,9 +6,6 @@ from typing import Callable, Dict
 from pygeoif import shape
 from sqlalchemy import and_, func, not_, or_
 
-from ... import values
-
-
 def parse_bbox(box, srid: int = None):
     minx, miny, maxx, maxy = box
     return func.ST_GeomFromEWKT(

--- a/pygeofilter/backends/sqlalchemy/filters.py
+++ b/pygeofilter/backends/sqlalchemy/filters.py
@@ -1,4 +1,3 @@
-import re
 from datetime import timedelta
 from functools import reduce
 from inspect import signature
@@ -6,6 +5,8 @@ from typing import Callable, Dict
 
 from pygeoif import shape
 from sqlalchemy import and_, func, not_, or_
+
+from ... import values
 
 
 def parse_bbox(box, srid: int = None):
@@ -18,11 +19,15 @@ def parse_bbox(box, srid: int = None):
     )
 
 
-def parse_geometry(geom):
+def parse_geometry(geom: dict):
+    crs_identifier = geom.get(
+        "crs", {}
+    ).get(
+        "properties", {}
+    ).get("name", "urn:ogc:def:crs:EPSG::4326")
+    srid = crs_identifier.rpartition("::")[-1]
     wkt = shape(geom).wkt
-    search = re.search(r"SRID=(\d+);", wkt)
-    sridtxt = "" if search else "SRID=4326;"
-    return func.ST_GeomFromEWKT(f"{sridtxt}{wkt}")
+    return func.ST_GeomFromEWKT(f"SRID={srid};{wkt}")
 
 
 # ------------------------------------------------------------------------------

--- a/tests/backends/sqlalchemy/test_filters.py
+++ b/tests/backends/sqlalchemy/test_filters.py
@@ -1,0 +1,34 @@
+from typing import cast
+import pytest
+
+from pygeofilter.backends.sqlalchemy import filters
+
+
+@pytest.mark.parametrize("geom, expected", [
+    pytest.param(
+        {
+            "type": "Point",
+            "coordinates": [10, 12]
+        },
+        "ST_GeomFromEWKT('SRID=4326;POINT (10 12)')",
+        id="without-crs"
+    ),
+    pytest.param(
+        {
+            "type": "Point",
+            "coordinates": [1, 2],
+            "crs": {
+                "type": "name",
+                "properties": {
+                    "name": "urn:ogc:def:crs:EPSG::3004"
+                }
+            }
+        },
+        "ST_GeomFromEWKT('SRID=3004;POINT (1 2)')",
+        id="with-crs"
+    ),
+])
+def test_parse_geometry(geom, expected):
+    parsed = filters.parse_geometry(cast(dict, geom))
+    result = str(parsed.compile(compile_kwargs={"literal_binds": True}))
+    assert result == expected


### PR DESCRIPTION
This PR refactors parsing of geometries done in the sqlalchemy backend in order to recognize custom CRS definitions.

Further discussion in #66 

Included also a couple of tests which should clarify the result of the proposed modification.


- fixes #66