### PR TITLE
Removed custom pygeoif version from requirements-test

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,6 @@ pyproj
 rtree
 pygml
 dateparser
-pygeoif==0.7
 lark
 elasticsearch
 elasticsearch-dsl


### PR DESCRIPTION
This PR removes the pinned `pygeoif` version in the requirements-test.txt file, since it is not compatible with the specification in `setup.py`

- fixes #85