### PR TITLE
isNull args as a list

### DIFF
--- a/pygeofilter/backends/cql2_json/evaluate.py
+++ b/pygeofilter/backends/cql2_json/evaluate.py
@@ -75,7 +75,7 @@ class CQL2Evaluator(Evaluator):
 
     @handle(ast.IsNull)
     def isnull(self, node, arg):
-        return {"op": "isNull", "args": arg}
+        return {"op": "isNull", "args": [arg]}
 
     @handle(ast.Function)
     def function(self, node, *args):

--- a/pygeofilter/parsers/cql2_json/parser.py
+++ b/pygeofilter/parsers/cql2_json/parser.py
@@ -125,7 +125,10 @@ def walk_cql_json(node: JsonType):  # noqa: C901
             return ast.Not(cast(ast.Node, walk_cql_json(args)))
 
         elif op == "isNull":
-            return ast.IsNull(cast(ast.Node, walk_cql_json(args)), False)
+            # like with "not", allow both arrays and objects
+            if isinstance(args, list):
+                args = args[0]
+            return ast.IsNull(cast(ast.Node, walk_cql_json(args)), not_=False)
 
         elif op == "between":
             return ast.Between(
@@ -150,12 +153,6 @@ def walk_cql_json(node: JsonType):  # noqa: C901
             return ast.In(
                 cast(ast.AstType, walk_cql_json(args[0])),
                 cast(List[ast.AstType], walk_cql_json(args[1])),
-                not_=False,
-            )
-
-        elif op == "isNull":
-            return ast.IsNull(
-                walk_cql_json(args),
                 not_=False,
             )
 

--- a/tests/parsers/cql2_json/fixtures.json
+++ b/tests/parsers/cql2_json/fixtures.json
@@ -33,7 +33,7 @@
     },
     "Example 9": {
         "text": "filter=sentinel:data_coverage > 50 OR landsat:coverage_percent < 10 OR (sentinel:data_coverage IS NULL AND landsat:coverage_percent IS NULL)",
-        "json": "{\"filter-lang\": \"cql2-json\", \"filter\": {\"op\": \"or\", \"args\": [{\"op\": \">\", \"args\": [{\"property\": \"sentinel:data_coverage\"}, 50]}, {\"op\": \"<\", \"args\": [{\"property\": \"landsat:coverage_percent\"}, 10]}, {\"op\": \"and\", \"args\": [{\"op\": \"isNull\", \"args\": {\"property\": \"sentinel:data_coverage\"}}, {\"op\": \"isNull\", \"args\": {\"property\": \"landsat:coverage_percent\"}}]}]}}"
+        "json": "{\"filter-lang\": \"cql2-json\", \"filter\": {\"op\": \"or\", \"args\": [{\"op\": \">\", \"args\": [{\"property\": \"sentinel:data_coverage\"}, 50]}, {\"op\": \"<\", \"args\": [{\"property\": \"landsat:coverage_percent\"}, 10]}, {\"op\": \"and\", \"args\": [{\"op\": \"isNull\", \"args\": [{\"property\": \"sentinel:data_coverage\"}]}, {\"op\": \"isNull\", \"args\": [{\"property\": \"landsat:coverage_percent\"}]}]}]}}"
     },
     "Example 10": {
         "text": "filter=eo:cloud_cover BETWEEN 0 AND 50",

--- a/tests/parsers/cql2_json/test_parser.py
+++ b/tests/parsers/cql2_json/test_parser.py
@@ -145,7 +145,7 @@ def test_attribute_in_list():
 
 
 def test_attribute_is_null():
-    result = parse({"op": "isNull", "args": {"property": "attr"}})
+    result = parse({"op": "isNull", "args": [{"property": "attr"}]})
     assert result == ast.IsNull(ast.Attribute("attr"), False)
 
 


### PR DESCRIPTION
Resolves #91 

Accepts `isNull` args as both arrays and objects for consistency with `not` implementation. However it's worth noting that the comment regarding the standard being ambiguous might be outdated as the standard seems relatively clear to me:
```
notExpression:
      type: object
      required:
        - op
        - args
      properties:
        op:
          type: string
          enum:
            - not
        args:
          type: array
          minItems: 1
          maxItems: 1
          items:
            $ref: '#/components/schemas/booleanExpression'
```
Likewise:
```
isNullPredicate:
      type: object
      required:
        - op
        - args
      properties:
        op:
          type: string
          enum:
            - isNull
        args:
          $ref: '#/components/schemas/isNullOperand'
    isNullOperand:
      type: array
      minItems: 1
      maxItems: 1
      items:
        oneOf:
          - $ref: '#/components/schemas/characterExpression'
          - $ref: '#/components/schemas/numericExpression'
          - $ref: '#/components/schemas/temporalExpression'
          - $ref: '#/components/schemas/booleanExpression'
          - $ref: '#/components/schemas/geomExpression'
```