### PR TITLE
Support prefixed attribute names in cql2-text and ecql parsing

### DIFF
--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -53,6 +53,7 @@
           | expression "LIKE"i SINGLE_QUOTED                                 -> like
           | expression "IN"i "(" expression ( "," expression )* ")"          -> in_
           | expression "IS"i "NULL"i                                         -> null
+          | expression "IS"i "NOT"i "NULL"i                                  -> not_null
           | "INCLUDE"i                                                       -> include
           | "EXCLUDE"i                                                       -> exclude
           | spatial_predicate

--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -137,7 +137,7 @@ DATETIME: /[0-9]{4}-?[0-1][0-9]-?[0-3][0-9][T ][0-2][0-9]:?[0-5][0-9]:?[0-5][0-9
 
 
 
-attribute: /[a-zA-Z][a-zA-Z_:0-9]+/
+attribute: /[a-zA-Z][a-zA-Z_:0-9.]+/
          | DOUBLE_QUOTED
 
 

--- a/pygeofilter/parsers/ecql/grammar.lark
+++ b/pygeofilter/parsers/ecql/grammar.lark
@@ -114,7 +114,7 @@ BOOLEAN: ( "TRUE" | "FALSE" )
 DOUBLE_QUOTED: "\"" /.*?/ "\""
 SINGLE_QUOTED: "'" /.*?/ "'"
 
-QUALIFIED_NAME: NAME ":" NAME
+QUALIFIED_NAME: (NAME ("." | ":"))+ NAME
 
 %import .wkt.ewkt_geometry
 %import .iso8601.DATETIME

--- a/tests/parsers/ecql/test_parser.py
+++ b/tests/parsers/ecql/test_parser.py
@@ -41,6 +41,12 @@ def test_namespace_attribute_eq_literal():
         "A",
     )
 
+def test_prefixed_attribute_eq_literal():
+    result = parse("properties.ns:attr = 'A'")
+    assert result == ast.Equal(
+        ast.Attribute("properties.ns:attr"),
+        "A",
+    )
 
 def test_attribute_eq_literal():
     result = parse("attr = 'A'")


### PR DESCRIPTION
According to the [CQL grammar spec](https://portal.ogc.org/files/96288#cql-bnf), an attribute name should be allowed to contain a period, such as in the case of `properties.eo:cloud_cover`. Currently, ecql and cql2-text parsers only support this if the name is in double quotes. Tweak the lark grammars to accept prefixed names without the need for quotes.

Also take the opportunity to add "IS NOT NULL" to cql2-text lark grammar, which seems to have been erroneously omitted.