### PR TITLE
Enable custom handling of undefined field attr in to_filter

### DIFF
--- a/pygeofilter/backends/sqlalchemy/filters.py
+++ b/pygeofilter/backends/sqlalchemy/filters.py
@@ -4,7 +4,7 @@ from inspect import signature
 from typing import Callable, Dict
 
 from pygeoif import shape
-from sqlalchemy import and_, func, not_, or_
+from sqlalchemy import and_, func, not_, or_, null
 
 def parse_bbox(box, srid: int = None):
     minx, miny, maxx, maxy = box
@@ -256,15 +256,21 @@ def bbox(lhs, minx, miny, maxx, maxy, crs=4326):
     return lhs.ST_Intersects(parse_bbox([minx, miny, maxx, maxy], crs))
 
 
-def attribute(name, field_mapping=None):
+def attribute(name, field_mapping={}, undefined_as_null: bool = None):
     """Create an attribute lookup expression using a field mapping dictionary.
 
     :param name: the field filter name
     :param field_mapping: the dictionary to use as a lookup.
+    :param undefined_as_null: how to handle a name not present in field_mapping
+        (None (default) - leave as-is; True - treat as null; False - throw error)
     """
-    field = field_mapping.get(name, name)
-
-    return field
+    if undefined_as_null is None:
+        return field_mapping.get(name, name)
+    if undefined_as_null:
+        # return null object if name is not found in field_mapping
+        return field_mapping.get(name, null())
+    # undefined_as_null is False, so raise KeyError if name not found
+    return field_mapping[name]
 
 
 def literal(value):


### PR DESCRIPTION
In `to_sql_where`, if an attribute name is not present in the `field_mapping`, a `KeyError` will be thrown. Meanwhile, in the roughly analogous Django and SQLAlchemy integrations, `to_filter` will treat an invalid/undefined attribute name as a string. Thus, `randomAttr = 'A'` will evaluate to False, and `randomAttr > 10` will throw `TypeError: '>' not supported between instances of 'str' and 'int'`; likewise, `randomAttr IS NULL` will throw an `AttributeError`.
I found this behaviour unexpected, and also difficult to integrate into an implementation of, for instance, the STAC API filter extension, where invalid properties need to be handled differently according to the context.
I think it would be useful to enable greater control over how unknown attribute names are handled, via an optional boolean parameter, `undefined_as_null`. If `None` (default), we retain the current behaviour. If `False`, the `field_mapping` lookup would throw a `KeyError`. If `True`, the attribute will evaluate to `NULL`. 
Note that I've started with implementing this change only for the SQLAlchemy integration, as that is my current use case and what I am most familiar with, but ideally this behaviour would be consistent across the backend integrations.