### PR TITLE
Fix parsing of booleanLiterals in cql2-text

### DIFF
--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -126,7 +126,7 @@ func.2: attribute "(" expression ("," expression)* ")" -> function
 
 envelope: "ENVELOPE"i "(" number number number number ")"
 
-BOOLEAN: ( "TRUE" | "FALSE" )
+BOOLEAN.2: ( "TRUE"i | "FALSE"i)
 
 DOUBLE_QUOTED: "\"" /.*?/ "\""
 SINGLE_QUOTED: "'" /.*?/ "'"

--- a/pygeofilter/parsers/cql2_text/parser.py
+++ b/pygeofilter/parsers/cql2_text/parser.py
@@ -178,8 +178,8 @@ class CQLTransformer(WKTTransformer, ISO8601Transformer):
     def FLOAT(self, value):
         return float(value)
 
-    def boolean(self, value):
-        return value in ("TRUE", "true", "T", "t", "1")
+    def BOOLEAN(self, value):
+        return value.lower() == "true"
 
     def DOUBLE_QUOTED(self, token):
         return token[1:-1]

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -1,0 +1,33 @@
+from pygeofilter import ast
+from pygeofilter.parsers.cql2_text import parse
+
+
+def test_attribute_eq_true_uppercase():
+    result = parse("attr = TRUE")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        True,
+    )
+
+def test_attribute_eq_true_lowercase():
+    result = parse("attr = true")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        True,
+    )
+
+
+def test_attribute_eq_false_uppercase():
+    result = parse("attr = FALSE")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        False,
+    )
+
+
+def test_attribute_eq_false_lowercase():
+    result = parse("attr = false")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        False,
+    )


### PR DESCRIPTION
Uses Lark's terminal priority to ensure that `booleanLiteral` values (case-insensitive `TRUE`/`FALSE`) are parsed as such and not as attributes (which is currently the case).

I attempted to run the pre-commit formatters/linters but I could not install `isort` using the version of `poetry` currently installed on my system and bumping the `isort` version in `.pre-commit-config.yaml` introduced some changes to the sorting rules that affected multiple files. I am happy to include updates to the pre-commit dependencies as a sidecar change to this PR or to open a separate PR with those changes.

Addresses #95.