### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         language_version: python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.10.0
     hooks:
       - id: mypy
         language_version: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         language_version: python
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 7.0.0
     hooks:
       - id: flake8
         language_version: python

--- a/pygeofilter/ast.py
+++ b/pygeofilter/ast.py
@@ -62,7 +62,7 @@ class Node:
         raise NotImplementedError
 
     def __eq__(self, other) -> bool:
-        if type(self) != type(other):
+        if not isinstance(other, self.__class__):
             return False
 
         self_dict = {

--- a/pygeofilter/backends/native/evaluate.py
+++ b/pygeofilter/backends/native/evaluate.py
@@ -71,8 +71,8 @@ class NativeEvaluator(Evaluator):
 
     def __init__(
         self,
-        function_map: Dict[str, Callable] = None,
-        attribute_map: Dict[str, str] = None,
+        function_map: Optional[Dict[str, Callable]] = None,
+        attribute_map: Optional[Dict[str, str]] = None,
         use_getattr: bool = True,
         allow_nested_attributes: bool = True,
     ):

--- a/pygeofilter/backends/optimize.py
+++ b/pygeofilter/backends/optimize.py
@@ -27,7 +27,7 @@
 
 import operator
 from datetime import date, datetime, time, timedelta
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional
 
 import shapely
 
@@ -341,7 +341,9 @@ def relate_intervals(lhs, rhs):  # noqa: C901
     raise ValueError(f"Error relating intervals [{ll}, {lh}] and ({rl}, {rh})")
 
 
-def optimize(root: ast.Node, function_map: Dict[str, Callable] = None) -> ast.Node:
+def optimize(
+    root: ast.Node, function_map: Optional[Dict[str, Callable]] = None
+) -> ast.Node:
     result = OptimizeEvaluator(function_map or {}).evaluate(root)
     if isinstance(result, bool):
         result = ast.Include(not result)

--- a/pygeofilter/backends/sqlalchemy/filters.py
+++ b/pygeofilter/backends/sqlalchemy/filters.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict
 from pygeoif import shape
 from sqlalchemy import and_, func, not_, or_
 
+
 def parse_bbox(box, srid: int = None):
     minx, miny, maxx, maxy = box
     return func.ST_GeomFromEWKT(
@@ -17,11 +18,11 @@ def parse_bbox(box, srid: int = None):
 
 
 def parse_geometry(geom: dict):
-    crs_identifier = geom.get(
-        "crs", {}
-    ).get(
-        "properties", {}
-    ).get("name", "urn:ogc:def:crs:EPSG::4326")
+    crs_identifier = (
+        geom.get("crs", {})
+        .get("properties", {})
+        .get("name", "urn:ogc:def:crs:EPSG::4326")
+    )
     srid = crs_identifier.rpartition("::")[-1]
     wkt = shape(geom).wkt
     return func.ST_GeomFromEWKT(f"SRID={srid};{wkt}")

--- a/pygeofilter/backends/sqlalchemy/filters.py
+++ b/pygeofilter/backends/sqlalchemy/filters.py
@@ -1,13 +1,13 @@
 from datetime import timedelta
 from functools import reduce
 from inspect import signature
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional
 
 from pygeoif import shape
 from sqlalchemy import and_, func, not_, or_
 
 
-def parse_bbox(box, srid: int = None):
+def parse_bbox(box, srid: Optional[int] = None):
     minx, miny, maxx, maxy = box
     return func.ST_GeomFromEWKT(
         f"SRID={4326 if srid is None else srid};POLYGON(("
@@ -74,7 +74,7 @@ class Operator:
         "/": lambda f, a: f / a,
     }
 
-    def __init__(self, operator: str = None):
+    def __init__(self, operator: Optional[str] = None):
         if not operator:
             operator = "=="
 

--- a/pygeofilter/util.py
+++ b/pygeofilter/util.py
@@ -25,8 +25,8 @@
 # THE SOFTWARE.
 # ------------------------------------------------------------------------------
 
-from collections.abc import Mapping
 import re
+from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 
 from dateparser import parse as _parse_datetime
@@ -146,6 +146,7 @@ def like_pattern_to_re(like, nocase, wildcard, single_char, escape_char):
 
 class IdempotentDict(Mapping):
     "A dict class that always returns the key"
+
     def __getitem__(self, key):
         return key
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest
 pytest-django
 wheel
 mypy<=0.982
+types-dateparser

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ flake8
 pytest
 pytest-django
 wheel
-mypy<=0.982
+mypy<=1.10.0
 types-dateparser

--- a/setup.py
+++ b/setup.py
@@ -54,14 +54,16 @@ setup(
     license="MIT",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        "dateparser",
-        "lark<1.0",
-        "pygeoif>=1.0.0",
-        "dataclasses;python_version<'3.7'",
-    ]
-    if not on_rtd
-    else [],
+    install_requires=(
+        [
+            "dateparser",
+            "lark<1.0",
+            "pygeoif>=1.0.0",
+            "dataclasses;python_version<'3.7'",
+        ]
+        if not on_rtd
+        else []
+    ),
     extras_require={
         "backend-django": ["django"],
         "backend-sqlalchemy": ["geoalchemy2", "sqlalchemy"],

--- a/tests/backends/oraclesql/test_evaluate.py
+++ b/tests/backends/oraclesql/test_evaluate.py
@@ -45,37 +45,27 @@ FUNCTION_MAP = {}
 
 def test_between():
     where = to_sql_where(
-        parse("int_attr NOT BETWEEN 4 AND 6"),
-        FIELD_MAPPING,
-        FUNCTION_MAP
+        parse("int_attr NOT BETWEEN 4 AND 6"), FIELD_MAPPING, FUNCTION_MAP
     )
     assert where == "(int_attr NOT BETWEEN 4 AND 6)"
 
 
 def test_between_with_binds():
     where, binds = to_sql_where_with_bind_variables(
-        parse("int_attr NOT BETWEEN 4 AND 6"),
-        FIELD_MAPPING,
-        FUNCTION_MAP
+        parse("int_attr NOT BETWEEN 4 AND 6"), FIELD_MAPPING, FUNCTION_MAP
     )
     assert where == "(int_attr NOT BETWEEN :int_attr_low_0 AND :int_attr_high_0)"
     assert binds == {"int_attr_low_0": 4, "int_attr_high_0": 6}
 
 
 def test_like():
-    where = to_sql_where(
-        parse("str_attr LIKE 'foo%'"),
-        FIELD_MAPPING,
-        FUNCTION_MAP
-    )
+    where = to_sql_where(parse("str_attr LIKE 'foo%'"), FIELD_MAPPING, FUNCTION_MAP)
     assert where == "str_attr LIKE 'foo%' ESCAPE '\\'"
 
 
 def test_like_with_binds():
     where, binds = to_sql_where_with_bind_variables(
-        parse("str_attr LIKE 'foo%'"),
-        FIELD_MAPPING,
-        FUNCTION_MAP
+        parse("str_attr LIKE 'foo%'"), FIELD_MAPPING, FUNCTION_MAP
     )
     assert where == "str_attr LIKE :str_attr_0 ESCAPE '\\'"
     assert binds == {"str_attr_0": "foo%"}
@@ -83,18 +73,14 @@ def test_like_with_binds():
 
 def test_combination():
     where = to_sql_where(
-        parse("int_attr = 5 AND float_attr < 6.0"),
-        FIELD_MAPPING,
-        FUNCTION_MAP
+        parse("int_attr = 5 AND float_attr < 6.0"), FIELD_MAPPING, FUNCTION_MAP
     )
     assert where == "((int_attr = 5) AND (float_attr < 6.0))"
 
 
 def test_combination_with_binds():
     where, binds = to_sql_where_with_bind_variables(
-        parse("int_attr = 5 AND float_attr < 6.0"),
-        FIELD_MAPPING,
-        FUNCTION_MAP
+        parse("int_attr = 5 AND float_attr < 6.0"), FIELD_MAPPING, FUNCTION_MAP
     )
     assert where == "((int_attr = :int_attr_0) AND (float_attr < :float_attr_1))"
     assert binds == {"int_attr_0": 5, "float_attr_1": 6.0}
@@ -107,8 +93,8 @@ def test_spatial():
         FUNCTION_MAP,
     )
     geo_json = (
-        "{\"type\": \"Polygon\", "
-        "\"coordinates\": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}"
+        '{"type": "Polygon", '
+        '"coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}'
     )
     assert where == (
         "SDO_RELATE(geometry_attr, "
@@ -124,8 +110,8 @@ def test_spatial_with_binds():
         FUNCTION_MAP,
     )
     geo_json = (
-        "{\"type\": \"Polygon\", "
-        "\"coordinates\": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}"
+        '{"type": "Polygon", '
+        '"coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}'
     )
     assert where == (
         "SDO_RELATE(geometry_attr, "
@@ -142,7 +128,7 @@ def test_bbox():
         FUNCTION_MAP,
     )
     geo_json = (
-        "{\"type\": \"Polygon\", \"coordinates\": [["
+        '{"type": "Polygon", "coordinates": [['
         "[-140.99778, 41.6751050889], "
         "[-140.99778, 83.23324], "
         "[-52.6480987209, 83.23324], "
@@ -163,7 +149,7 @@ def test_bbox_with_binds():
         FUNCTION_MAP,
     )
     geo_json = (
-        "{\"type\": \"Polygon\", \"coordinates\": [["
+        '{"type": "Polygon", "coordinates": [['
         "[-140.99778, 41.6751050889], "
         "[-140.99778, 83.23324], "
         "[-52.6480987209, 83.23324], "

--- a/tests/backends/sqlalchemy/test_filters.py
+++ b/tests/backends/sqlalchemy/test_filters.py
@@ -1,33 +1,32 @@
 from typing import cast
+
 import pytest
 
 from pygeofilter.backends.sqlalchemy import filters
 
 
-@pytest.mark.parametrize("geom, expected", [
-    pytest.param(
-        {
-            "type": "Point",
-            "coordinates": [10, 12]
-        },
-        "ST_GeomFromEWKT('SRID=4326;POINT (10 12)')",
-        id="without-crs"
-    ),
-    pytest.param(
-        {
-            "type": "Point",
-            "coordinates": [1, 2],
-            "crs": {
-                "type": "name",
-                "properties": {
-                    "name": "urn:ogc:def:crs:EPSG::3004"
-                }
-            }
-        },
-        "ST_GeomFromEWKT('SRID=3004;POINT (1 2)')",
-        id="with-crs"
-    ),
-])
+@pytest.mark.parametrize(
+    "geom, expected",
+    [
+        pytest.param(
+            {"type": "Point", "coordinates": [10, 12]},
+            "ST_GeomFromEWKT('SRID=4326;POINT (10 12)')",
+            id="without-crs",
+        ),
+        pytest.param(
+            {
+                "type": "Point",
+                "coordinates": [1, 2],
+                "crs": {
+                    "type": "name",
+                    "properties": {"name": "urn:ogc:def:crs:EPSG::3004"},
+                },
+            },
+            "ST_GeomFromEWKT('SRID=3004;POINT (1 2)')",
+            id="with-crs",
+        ),
+    ],
+)
 def test_parse_geometry(geom, expected):
     parsed = filters.parse_geometry(cast(dict, geom))
     result = str(parsed.compile(compile_kwargs={"literal_binds": True}))

--- a/tests/parsers/cql2_json/get_fixtures.py
+++ b/tests/parsers/cql2_json/get_fixtures.py
@@ -1,4 +1,5 @@
 """Get fixtures from the spec."""
+
 import json
 import re
 


### PR DESCRIPTION
Bumps the versions of all `pre-commit` dependencies (`black`, `flake8`, `isort`, and `mypy`) to the latest available versions and makes the minimal set of code changes necessary to satisfy all formatters/linters.