### PR TITLE
add FES parser import shortcut as other filter languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .doctrees
 
 .vscode
+.idea

--- a/pygeofilter/parsers/fes/__init__.py
+++ b/pygeofilter/parsers/fes/__init__.py
@@ -1,0 +1,3 @@
+from .parser import parse
+
+__all__ = ["parse"]


### PR DESCRIPTION
Add the missing import shortcut for `fes`.

This allows to do 
```python
from pygeofilter.parsers import cql_json, cql2_json, cql2_text, ecql, fes, jfe

cql_json.parse(...)
cql2_json.parse(...)
cql2_text.parse(...)
ecql.parse(...)
fes.parse(...)   # only this one was not possible before
jfe.parse(...)
```