### PR TITLE
Handle boolean in ecql like cql_text

### DIFF
--- a/pygeofilter/parsers/ecql/grammar.lark
+++ b/pygeofilter/parsers/ecql/grammar.lark
@@ -109,7 +109,7 @@ period: DATETIME "/" DATETIME
 
 envelope: "ENVELOPE" "(" number number number number ")"
 
-BOOLEAN: ( "TRUE" | "FALSE" )
+BOOLEAN.2: ( "TRUE"i | "FALSE"i )
 
 DOUBLE_QUOTED: "\"" /.*?/ "\""
 SINGLE_QUOTED: "'" /.*?/ "'"

--- a/pygeofilter/parsers/ecql/parser.py
+++ b/pygeofilter/parsers/ecql/parser.py
@@ -181,7 +181,7 @@ class ECQLTransformer(WKTTransformer, ISO8601Transformer):
         return float(value)
 
     def BOOLEAN(self, value):
-        return value == "TRUE"
+        return value.lower() == "true"
 
     def DOUBLE_QUOTED(self, token):
         return token[1:-1]

--- a/tests/parsers/ecql/test_parser.py
+++ b/tests/parsers/ecql/test_parser.py
@@ -41,12 +41,14 @@ def test_namespace_attribute_eq_literal():
         "A",
     )
 
+
 def test_prefixed_attribute_eq_literal():
     result = parse("properties.ns:attr = 'A'")
     assert result == ast.Equal(
         ast.Attribute("properties.ns:attr"),
         "A",
     )
+
 
 def test_attribute_eq_literal():
     result = parse("attr = 'A'")
@@ -594,4 +596,36 @@ def test_function_attr_string_arg():
                 "abc",
             ],
         ),
+    )
+
+
+def test_attribute_eq_true_uppercase():
+    result = parse("attr = TRUE")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        True,
+    )
+
+
+def test_attribute_eq_true_lowercase():
+    result = parse("attr = true")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        True,
+    )
+
+
+def test_attribute_eq_false_uppercase():
+    result = parse("attr = FALSE")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        False,
+    )
+
+
+def test_attribute_eq_false_lowercase():
+    result = parse("attr = false")
+    assert result == ast.Equal(
+        ast.Attribute("attr"),
+        False,
     )


### PR DESCRIPTION
For the moment

```python
    assert parse("attr = true") == ast.Equal(
        ast.Attribute("attr"),
        ast.Attribute("true"),
    )
```
like https://github.com/geopython/pygeofilter/pull/96, use lark terminal priority to ensure boolean are parsed as such and not as attribute.