### PR TITLE
Add support for CQL2's CASEI (fixes #135)

### DIFF
--- a/pygeofilter/backends/sqlalchemy/evaluate.py
+++ b/pygeofilter/backends/sqlalchemy/evaluate.py
@@ -112,10 +112,9 @@ class SQLAlchemyFilterEvaluator(Evaluator):
     def arithmetic(self, node, lhs, rhs):
         return filters.runop(lhs, rhs, node.op.value)
 
-    # TODO: map functions
-    # @handle(ast.FunctionExpressionNode)
-    # def function(self, node, *arguments):
-    #     return self.function_map[node.name](*arguments)
+    @handle(ast.Function)
+    def function(self, node, *arguments):
+        return filters.function_map[node.name](*arguments)
 
     @handle(*values.LITERALS)
     def literal(self, node):

--- a/pygeofilter/backends/sqlalchemy/filters.py
+++ b/pygeofilter/backends/sqlalchemy/filters.py
@@ -27,6 +27,10 @@ def parse_geometry(geom: dict):
     wkt = shape(geom).wkt
     return func.ST_GeomFromEWKT(f"SRID={srid};{wkt}")
 
+# TODO: map functions
+function_map = {
+    "lower": func.lower
+}
 
 # ------------------------------------------------------------------------------
 # Filters

--- a/pygeofilter/parsers/cql2_json/parser.py
+++ b/pygeofilter/parsers/cql2_json/parser.py
@@ -157,6 +157,9 @@ def walk_cql_json(node: JsonType):  # noqa: C901
                 cast(List[ast.AstType], walk_cql_json(args[1])),
                 not_=False,
             )
+        
+        elif op == "casei":
+            return ast.Function("lower", [cast(ast.Node, walk_cql_json(args[0]))])
 
         elif op in BINARY_OP_PREDICATES_MAP:
             args = [cast(ast.Node, walk_cql_json(arg)) for arg in args]

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -297,7 +297,7 @@ def test_string_not_null(db_session):
 
 # CASEI
 def test_casei(db_session):
-    evaluate(db_session, "CASEI(strAttribute) = 'aaa'", ("A",), None, parse_cql_text)
+    evaluate(db_session, "CASEI(strAttribute) = CASEI('aaa')", ("A",), None, parse_cql_text)
 
 
 # temporal predicates

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -294,6 +294,10 @@ def test_string_null(db_session):
 def test_string_not_null(db_session):
     evaluate(db_session, "intAttribute IS NOT NULL", ("A",))
 
+# CASEI
+def test_casei(db_session):
+    evaluate(db_session, "strAttribute = CASEI('aaa')", ("A",))
+
 
 # temporal predicates
 

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -297,7 +297,7 @@ def test_string_not_null(db_session):
 
 # CASEI
 def test_casei(db_session):
-    evaluate(db_session, "strAttribute = CASEI('aaa')", ("A",), None, parse_cql_text)
+    evaluate(db_session, "CASEI(strAttribute) = 'aaa'", ("A",), None, parse_cql_text)
 
 
 # temporal predicates

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -18,7 +18,8 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql import func, select
 
 from pygeofilter.backends.sqlalchemy.evaluate import to_filter
-from pygeofilter.parsers.ecql import parse
+from pygeofilter.parsers.ecql import parse as parse_ecql
+from pygeofilter.parsers.cql2_text import parse as parse_cql_text
 
 Base = declarative_base()
 
@@ -161,8 +162,8 @@ def db_session(setup_database, connection):
     transaction.rollback()
 
 
-def evaluate(session, cql_expr, expected_ids, filter_option=None):
-    ast = parse(cql_expr)
+def evaluate(session, cql_expr, expected_ids, filter_option=None, parser=parse_ecql):
+    ast = parser(cql_expr)
     filters = to_filter(ast, FIELD_MAPPING, filter_option)
 
     q = session.query(Record).join(RecordMeta).filter(filters)
@@ -296,7 +297,7 @@ def test_string_not_null(db_session):
 
 # CASEI
 def test_casei(db_session):
-    evaluate(db_session, "strAttribute = CASEI('aaa')", ("A",))
+    evaluate(db_session, "strAttribute = CASEI('aaa')", ("A",), None, parse_cql_text)
 
 
 # temporal predicates

--- a/tests/parsers/cql2_json/test_parser.py
+++ b/tests/parsers/cql2_json/test_parser.py
@@ -148,6 +148,13 @@ def test_attribute_is_null():
     result = parse({"op": "isNull", "args": [{"property": "attr"}]})
     assert result == ast.IsNull(ast.Attribute("attr"), False)
 
+def test_attribute_casei():
+    result = parse('{"op": "casei", "args": [{"property": "attr"}]}')
+    assert result == ast.Function("lower", [ast.Attribute("attr")])
+
+def test_literal_casei():
+    result = parse('{"op": "casei", "args": ["literal"]}')
+    assert result == ast.Function("lower", ["literal"])
 
 def test_attribute_before():
     result = parse(


### PR DESCRIPTION
This PR fixes #135 by adding:
- support for CASEI in the cql2_json parser,
- support for "lower" functions in the sqlalchemy backend

CASEI is specified in in the [Case-insensitive Comparison requirements class of the CQL2 standard](https://docs.ogc.org/is/21-065r2/21-065r2.html#case-insensitive-comparison). 

```python
from pygeofilter.parsers.cql2_text import parse as parse_text
from pygeofilter.parsers.cql2_json import parse as parse_json

parse_text("CASEI(road_class) IN (CASEI('Οδος'),CASEI('Straße'))")
#> In(lhs=Function(name='lower', arguments=[ATTRIBUTE road_class]), sub_nodes=[Function(name='lower', arguments=['Οδος']), Function(name='lower', arguments=['Straße'])], not_=False)

parse_json('{"op": "in", "args": [{"op": "casei", "args": [{"property": "road_class"}]}, [{"op": "casei", "args": ["Οδος"]}, {"op": "casei", "args": ["Straße"]}]]}')
#> In(lhs=Function(name='lower', arguments=[ATTRIBUTE road_class]), sub_nodes=[Function(name='lower', arguments=['Οδος']), Function(name='lower', arguments=['Straße'])], not_=False)

parse_text("CASEI(road_class) IN (CASEI('Οδος'),CASEI('Straße'))") == parse_json('{"op": "in", "args": [{"op": "casei", "args": [{"property": "road_class"}]}, [{"op": "casei", "args": ["Οδος"]}, {"op": "cas\
ei", "args": ["Straße"]}]]}')
#> True

from sqlalchemy import Column, String
from sqlalchemy.dialects import postgresql
from pygeofilter.backends.sqlalchemy.evaluate import to_filter
expr=to_filter(parse_text("road_class IN (CASEI('Οδος'),CASEI('Straße'))"), { "road_class": Column(String, name="road_class") })
str(expr.compile(dialect=postgresql.dialect()))
#> 'road_class IN (lower(%(lower_1)s), lower(%(lower_2)s))'
```