### PR TITLE
Fix in_(): quote string values to handle colons in Solr identifiers

### DIFF
--- a/pygeofilter/backends/solr/evaluate.py
+++ b/pygeofilter/backends/solr/evaluate.py
@@ -286,7 +286,11 @@ class SOLRDSLEvaluator(Evaluator):
         """
         Creates a terms query for `IN` conditions.
         """
-        options_str = " OR ".join(str(option) for option in options)
+        def _quote(v):
+            if isinstance(v, str):
+                return '"' + v.replace('"', '\\"') + '"'
+            return str(v)
+        options_str = " OR ".join(_quote(option) for option in options)
         terms_query = f"{lhs}:({options_str})"
         if node.not_:
             # Negate the terms query for NOT IN


### PR DESCRIPTION
## Problem

`in_()` interpolates option values bare into the Solr query string:

```
field:(value1 OR value2)
```

This breaks silently when any value contains a colon. Solr's query parser
treats a bare colon as a field separator, so an identifier like
`no.met.adc:fe10e5c9-a226-58be-829e-cfe5c3a3fc45` is parsed as field `no.met.adc`
with value `fe10e5c9-...`, which either silently matches the wrong field or raises
a Solr parse error (`undefined field no.met.adc`).

This is the same class of bug already fixed in `equality()` — that fix wraps
the RHS string in double quotes. `in_()` was missed.

**Real-world case:** STAC `POST /search` with an `ids` or `collections` filter
containing namespaced identifiers (common in OGC/ISO metadata catalogues that use
`authority:uuid` or `scheme:localid` conventions).

## Fix

Wrap each string option in double quotes, escaping any embedded double quotes.
Numeric values are left unchanged.

```python
def _quote(v):
    if isinstance(v, str):
        return '"' + v.replace('"', '\\"') + '"'
    return str(v)
options_str = " OR ".join(_quote(option) for option in options)
```

Produces:

```
field:("value1" OR "no.met.adc:fe10e5c9-...")
```

which Solr parses correctly as phrase/term queries.

## Context

Found while testing the MET Norway pycsw Solr plugin against a live STAC API
endpoint. Collection and item identifiers follow the `authority:uuid` pattern
throughout the ADC/NBS/GCW Arctic metadata catalogues.

The companion fix in `equality()` (already in main) uses the same quoting
approach for single-value equality comparisons; this PR extends it to
multi-value IN filters for consistency.

gh pr create \
  --repo geopython/pygeofilter \
  --base main \
  --head epifanio:fix/solr-backend-bugs \
  --title "Fix in_(): quote string values to handle colons and special characters in Solr identifiers" \
  --body-file /tmp/pygeofilter_pr_body.md 2>&1