### PR TITLE
Update CASEI implementation to support LIKE

### DIFF
--- a/pygeofilter/ast.py
+++ b/pygeofilter/ast.py
@@ -32,7 +32,7 @@ from typing import ClassVar, List, Optional, Union
 from . import values
 
 AstType = Union["Node", values.ValueType, list]
-ScalarAstType = Union["Node", int, float]
+ScalarAstType = Union["Node", int, float, str]
 SpatialAstType = Union["Node", values.SpatialValueType]
 TemporalAstType = Union["Node", values.TemporalValueType]
 ArrayAstType = Union["Node", List[AstType]]
@@ -225,7 +225,7 @@ class Like(Predicate):
     """Node class to represent a wildcard sting matching predicate."""
 
     lhs: Node
-    pattern: str | AstType
+    pattern: ScalarAstType
     nocase: bool
     wildcard: str
     singlechar: str

--- a/pygeofilter/ast.py
+++ b/pygeofilter/ast.py
@@ -225,7 +225,7 @@ class Like(Predicate):
     """Node class to represent a wildcard sting matching predicate."""
 
     lhs: Node
-    pattern: str
+    pattern: str | AstType
     nocase: bool
     wildcard: str
     singlechar: str

--- a/pygeofilter/backends/sqlalchemy/evaluate.py
+++ b/pygeofilter/backends/sqlalchemy/evaluate.py
@@ -34,6 +34,8 @@ class SQLAlchemyFilterEvaluator(Evaluator):
 
     @handle(ast.Like)
     def like(self, node, lhs):
+        if (isinstance(node.pattern, ast.Function)):
+            node.pattern = filters.function_map[node.pattern.name](*node.pattern.arguments)
         return filters.like(
             lhs,
             node.pattern,

--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -51,8 +51,8 @@
           | expression "gte"i expression                                      -> gte
           | expression "BETWEEN"i expression "AND"i expression                -> between
           | expression "NOT"i "BETWEEN"i expression "AND"i expression         -> not_between
-          | expression "LIKE"i SINGLE_QUOTED                                 -> like
-          | expression "NOT"i "LIKE"i SINGLE_QUOTED                          -> not_like
+          | expression "LIKE"i expression                                 -> like
+          | expression "NOT"i "LIKE"i expression                          -> not_like
           | expression "IN"i "(" expression ( "," expression )* ")"          -> in_
           | expression "NOT"i "IN"i "(" expression ( "," expression )* ")"   -> not_in
           | expression "IS"i "NULL"i                                         -> null
@@ -112,7 +112,6 @@
      | "(" expression ")"
 
 func.2: attribute "(" expression ("," expression)* ")" -> function
-
 
 ?literal: timestamp
         | interval

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -296,9 +296,17 @@ def test_string_not_null(db_session):
     evaluate(db_session, "intAttribute IS NOT NULL", ("A",))
 
 # CASEI
-def test_casei(db_session):
+def test_casei_equals(db_session):
     evaluate(db_session, "CASEI(strAttribute) = CASEI('aaa')", ("A",), None, parse_cql_text)
 
+def test_casei_like(db_session):
+    evaluate(db_session, "CASEI(strAttribute) LIKE CASEI('aaa')", ("A",), None, parse_cql_text)
+
+def test_casei_notlike(db_session):
+    evaluate(db_session, "CASEI(strAttribute) NOT LIKE CASEI('aaa')", ("B", ), None, parse_cql_text)
+
+def test_casei_in(db_session):
+    evaluate(db_session, "CASEI(strAttribute) IN (CASEI('aaa'), CASEI('bbb'))", ("A", "B", ), None, parse_cql_text)
 
 # temporal predicates
 

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -20,6 +20,7 @@ from sqlalchemy.sql import func, select
 from pygeofilter.backends.sqlalchemy.evaluate import to_filter
 from pygeofilter.parsers.ecql import parse as parse_ecql
 from pygeofilter.parsers.cql2_text import parse as parse_cql_text
+from pygeofilter.parsers.cql2_json import parse as parse_cql2_json
 
 Base = declarative_base()
 
@@ -307,6 +308,9 @@ def test_casei_notlike(db_session):
 
 def test_casei_in(db_session):
     evaluate(db_session, "CASEI(strAttribute) IN (CASEI('aaa'), CASEI('bbb'))", ("A", "B", ), None, parse_cql_text)
+
+def test_casei_json_like(db_session):
+    evaluate(db_session, '{"op": "like", "args": [ {"op": "casei", "args": [{"property": "strAttribute"}]}, {"op": "casei", "args": ["AAA"]} ] }', ("A", ), None, parse_cql2_json)
 
 # temporal predicates
 

--- a/tests/parsers/cql2_json/test_parser.py
+++ b/tests/parsers/cql2_json/test_parser.py
@@ -156,6 +156,18 @@ def test_literal_casei():
     result = parse('{"op": "casei", "args": ["literal"]}')
     assert result == ast.Function("lower", ["literal"])
 
+def test_like_casei():
+    result = parse('{"op": "like", "args": [ {"op": "casei", "args": [{"property": "stringattr"}]}, {"op": "casei", "args": ["AAA"]} ] }')
+    assert result == ast.Like(
+        ast.Function("lower", [ast.Attribute("stringattr")]),
+        ast.Function("lower", ["AAA"]),
+        nocase=False,
+        not_=False,
+        wildcard="%",
+        singlechar=".",
+        escapechar="\\",
+    )
+
 def test_attribute_before():
     result = parse(
         {

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -409,11 +409,34 @@ def test_nested_and_or():
     assert result.rhs.rhs == ast.Equal(ast.Attribute("attr_d"), 4)
 
 
-def test_casei_function():
-    result = parse("CASEI(provider) = 'coolsat'")
+def test_casei_equals():
+    result = parse("CASEI(provider) = CASEI('coolsat')")
     # Assuming CASEI maps to 'lower' in the implementation
     assert isinstance(result, ast.Equal)
     assert isinstance(result.lhs, ast.Function)
+    assert isinstance(result.rhs, ast.Function)
     assert result.lhs.name == "lower"
     assert result.lhs.arguments == [ast.Attribute("provider")]
-    assert result.rhs == "coolsat"
+    assert result.rhs.name == "lower"
+    assert result.rhs.arguments == ["coolsat"]
+
+
+def test_casei_like():
+    result = parse("CASEI(provider) LIKE CASEI('coolsat')")
+    # Assuming CASEI maps to 'lower' in the implementation
+    assert isinstance(result, ast.Like)
+    assert isinstance(result.lhs, ast.Function)
+    assert result.lhs.name == "lower"
+    assert result.lhs.arguments == [ast.Attribute("provider")]
+    assert result.pattern.name == "lower"
+    assert result.pattern.arguments == ["coolsat"]
+
+def test_casei_notlike():
+    result = parse("CASEI(provider) NOT LIKE CASEI('coolsat')")
+    # Assuming CASEI maps to 'lower' in the implementation
+    assert isinstance(result, ast.Like)
+    assert isinstance(result.lhs, ast.Function)
+    assert result.lhs.name == "lower"
+    assert result.lhs.arguments == [ast.Attribute("provider")]
+    assert result.pattern.name == "lower"
+    assert result.pattern.arguments == ["coolsat"]


### PR DESCRIPTION
This PR updates the Lark grammar for CQL2 Text and adds tests for both CQL2 text and JSON to make CASEI work appropriately on the right-hand side of LIKE statements.