### PR TITLE
Allow NOT to take predicate in parens in CQL2

### DIFF
--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -33,8 +33,8 @@
 
 ?condition_1: predicate
             | "NOT"i predicate                                               -> not_
+            | "NOT"i "(" predicate ")"                                       -> not_
             | "(" condition ")"
-
 
 ?predicate: expression "=" expression                                       -> eq
           | expression "eq"i expression                                      -> eq

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -274,6 +274,11 @@ def test_not_like_endswith(db_session):
 def test_not_ilike_endswith(db_session):
     evaluate(db_session, "strMetaAttribute NOT ILIKE '%b'", ("A",))
 
+def test_not_eq(db_session):
+    evaluate(db_session, "NOT(strAttribute = 'AAA')", ("B", ), None, parse_cql_text)
+
+def test_not_gt(db_session):
+    evaluate(db_session, "NOT(floatAttribute > 1)", ("A", ), None, parse_cql_text)
 
 # (NOT) IN
 

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -440,3 +440,21 @@ def test_casei_notlike():
     assert result.lhs.arguments == [ast.Attribute("provider")]
     assert result.pattern.name == "lower"
     assert result.pattern.arguments == ["coolsat"]
+
+def test_not_gt():
+    result = parse("NOT(attr > 2)")
+    assert result == ast.Not(
+        ast.GreaterThan(ast.Attribute("attr"), 2)
+    )
+
+def test_not_lt():
+    result = parse("NOT(attr < 2)")
+    assert result == ast.Not(
+        ast.LessThan(ast.Attribute("attr"), 2)
+    )
+
+def test_not_eq():
+    result = parse("NOT(attr = 2)")
+    assert result == ast.Not(
+        ast.Equal(ast.Attribute("attr"), 2)
+    )


### PR DESCRIPTION
This PR fixes #134 by allowing NOT to take predicates inside of parenthesis in CQL2. 