### PR TITLE
Fix CQL2 bbox parsing to match standard

### DIFF
--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -59,7 +59,6 @@
           | expression "IS"i "NOT"i "NULL"i                                  -> not_null
           | "INCLUDE"i                                                       -> include
           | "EXCLUDE"i                                                       -> exclude
-          | bbox
           | spatial_predicate
           | temporal_predicate
 
@@ -122,6 +121,7 @@ func.2: attribute "(" expression ("," expression)* ")" -> function
         | SINGLE_QUOTED
         | ewkt_geometry                                                     -> geometry
         | envelope
+        | bbox
 
 ?full_number: number
             | "-" number                                                    -> neg

--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -59,6 +59,7 @@
           | expression "IS"i "NOT"i "NULL"i                                  -> not_null
           | "INCLUDE"i                                                       -> include
           | "EXCLUDE"i                                                       -> exclude
+          | bbox
           | spatial_predicate
           | temporal_predicate
 
@@ -83,7 +84,7 @@
 
 ?spatial_predicate: _binary_spatial_predicate_func "(" expression "," expression ")"                                -> binary_spatial_predicate
                   | "RELATE" "(" expression "," expression "," SINGLE_QUOTED ")"                                    -> relate_spatial_predicate
-                  | "BBOX" "(" expression "," full_number "," full_number "," full_number "," full_number [ ","  SINGLE_QUOTED] ")" -> bbox_spatial_predicate
+                  | _binary_spatial_predicate_func "(" expression "," bbox ")"                                      -> binary_spatial_predicate
 
 !_binary_spatial_predicate_func: "S_INTERSECTS"i
                                | "S_DISJOINT"i
@@ -128,6 +129,8 @@ func.2: attribute "(" expression ("," expression)* ")" -> function
 ?number: FLOAT | INT
 
 envelope: "ENVELOPE"i "(" number number number number ")"
+
+bbox: "BBOX"i "(" full_number "," full_number "," full_number "," full_number ")"
 
 BOOLEAN.2: ( "TRUE"i | "FALSE"i)
 

--- a/pygeofilter/parsers/cql2_text/parser.py
+++ b/pygeofilter/parsers/cql2_text/parser.py
@@ -190,7 +190,7 @@ class CQLTransformer(WKTTransformer, ISO8601Transformer):
     def geometry(self, value):
         return values.Geometry(value)
 
-    def envelope(self, x1, x2, y1, y2):
+    def bbox(self, x1, y1, x2, y2):
         return values.Envelope(x1, x2, y1, y2)
 
     def interval(self, start, end):

--- a/pygeofilter/values.py
+++ b/pygeofilter/values.py
@@ -44,7 +44,6 @@ class Geometry:
     def __eq__(self, o: object) -> bool:
         return shape(self).__geo_interface__ == shape(o).__geo_interface__
 
-
 @dataclass
 class Envelope:
     x1: float

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -401,6 +401,14 @@ def test_intersects_envelope(db_session):
 def test_bbox(db_session):
     evaluate(db_session, "BBOX(geometry, 0, 0, 1, 1, '4326')", ("A",))
 
+def test_bbox_cql2(db_session):
+    evaluate(db_session, "S_INTERSECTS(geometry, BBOX(0, 0, 1, 1))", ("A",), None, parse_cql_text)
+
+def test_empty_bbox_cql2(db_session):
+    evaluate(db_session, "S_INTERSECTS(geometry, BBOX(178, 88, 181, 91))", (), None, parse_cql_text)
+
+def test_global_bbox_cql2(db_session):
+    evaluate(db_session, "S_INTERSECTS(geometry,BBOX(-180,-90,180,90))", ("A", "B",), None, parse_cql_text)
 
 # arithmethic expressions
 

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -5,6 +5,23 @@ from dateparser.timezone_parser import StaticTzInfo
 from pygeofilter import ast, values
 from pygeofilter.parsers.cql2_text import parse
 
+def test_bbox():
+    result = parse("BBOX(160.6,-55.95,-170,-25.89)")
+    assert result == values.Envelope(160.6,-170,-55.95,-25.89)
+
+def test_intersect_bbox():
+    result = parse("S_INTERSECTS(geometry,BBOX(-180,-90,180,90))")
+    assert result == ast.GeometryIntersects(
+        ast.Attribute("geometry"),
+        values.Envelope(-180, 180, -90, 90)
+    )
+
+def test_intersect_point():
+    result = parse("S_INTERSECTS(geometry,POINT(7.02 49.92))")
+    assert result == ast.GeometryIntersects(
+        ast.Attribute("geometry"),
+        values.Geometry({'type': 'Point', 'coordinates': (7.02, 49.92)})
+    )
 
 def test_attribute_eq_true_uppercase():
     result = parse("attr = TRUE")

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -5,10 +5,6 @@ from dateparser.timezone_parser import StaticTzInfo
 from pygeofilter import ast, values
 from pygeofilter.parsers.cql2_text import parse
 
-def test_bbox():
-    result = parse("BBOX(160.6,-55.95,-170,-25.89)")
-    assert result == values.Envelope(160.6,-170,-55.95,-25.89)
-
 def test_intersect_bbox():
     result = parse("S_INTERSECTS(geometry,BBOX(-180,-90,180,90))")
     assert result == ast.GeometryIntersects(


### PR DESCRIPTION
This PR fixes #143 by reworking bbox parsing for CQL2 to match the standard. Rather than introducing a new class, I decided to parse bboxes using the existing envelope class. This might be a bit confusing as it requires mapping from xyxy -> xxyy, but seems to produce good results with the existing sqlalchemy backend without requiring a lot of work.