### PR TITLE
Add support for DATE in CQL2 Text

### DIFF
--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -115,6 +115,7 @@ func.2: attribute "(" expression ("," expression)* ")" -> function
 
 ?literal: timestamp
         | interval
+        | date
         | number
         | BOOLEAN
         | SINGLE_QUOTED
@@ -133,11 +134,11 @@ BOOLEAN.2: ( "TRUE"i | "FALSE"i)
 DOUBLE_QUOTED: "\"" /.*?/ "\""
 SINGLE_QUOTED: "'" /.*?/ "'"
 
+DATE: /[0-9]{4}-?[0-1][0-9]-?[0-3][0-9]/
 DATETIME: /[0-9]{4}-?[0-1][0-9]-?[0-3][0-9][T ][0-2][0-9]:?[0-5][0-9]:?[0-5][0-9](\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})?/
 ?timestamp: "TIMESTAMP" "(" "'" DATETIME "'" ")"
 ?interval: "INTERVAL" "("  "'" DATETIME "'" "," "'" DATETIME "'" ")"
-
-
+?date: "DATE" "(" "'" DATE "'" ")"
 
 attribute: /[a-zA-Z][a-zA-Z_:0-9.]+/
          | DOUBLE_QUOTED

--- a/pygeofilter/parsers/iso8601.py
+++ b/pygeofilter/parsers/iso8601.py
@@ -27,7 +27,7 @@
 
 from lark import Transformer, v_args
 
-from ..util import parse_datetime, parse_duration
+from ..util import parse_datetime, parse_duration, parse_date
 
 
 @v_args(meta=False, inline=True)
@@ -37,3 +37,6 @@ class ISO8601Transformer(Transformer):
 
     def DURATION(self, duration):
         return parse_duration(duration)
+    
+    def DATE(self, date):
+        return parse_date(date)

--- a/tests/backends/sqlalchemy/test_evaluate.py
+++ b/tests/backends/sqlalchemy/test_evaluate.py
@@ -319,6 +319,9 @@ def test_casei_json_like(db_session):
 
 # temporal predicates
 
+def test_date_gte(db_session):
+    evaluate(db_session, "datetimeAttribute >= DATE('2000-01-01')", ("A", "B",), None, parse_cql_text)
+
 
 def test_before(db_session):
     evaluate(db_session, "datetimeAttribute BEFORE 2000-01-01T00:00:01Z", ("A",))

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 from dateparser.timezone_parser import StaticTzInfo
 
@@ -201,6 +201,12 @@ def test_attribute_before():
         datetime(2000, 1, 1, 0, 0, 1, tzinfo=StaticTzInfo("Z", timedelta(0))),
     )
 
+def test_attribute_lt_date():
+    result = parse("attr < DATE('2000-01-01')")
+    assert result == ast.LessThan(
+        ast.Attribute("attr"),
+        date(2000, 1, 1),
+    )
 
 def test_attribute_t_intersects():
     # Using INTERVAL function with properly quoted timestamps


### PR DESCRIPTION
This PR adds support for DATE in CQL2 as defined in 6.3.1:
https://docs.ogc.org/is/21-065r2/21-065r2.html#scalar-data-types

