### PR TITLE
feat(cql2-text): add modulo, integer division, and power arithmetic operators

### DIFF
--- a/pygeofilter/ast.py
+++ b/pygeofilter/ast.py
@@ -632,6 +632,9 @@ class ArithmeticOp(Enum):
     SUB = "-"
     MUL = "*"
     DIV = "/"
+    MOD = "%"
+    INTDIV = "div"
+    POW = "^"
 
 
 @dataclass
@@ -669,6 +672,21 @@ class Mul(Arithmetic):
 @dataclass
 class Div(Arithmetic):
     op: ClassVar[ArithmeticOp] = ArithmeticOp.DIV
+
+
+@dataclass
+class Mod(Arithmetic):
+    op: ClassVar[ArithmeticOp] = ArithmeticOp.MOD
+
+
+@dataclass
+class IntDiv(Arithmetic):
+    op: ClassVar[ArithmeticOp] = ArithmeticOp.INTDIV
+
+
+@dataclass
+class Pow(Arithmetic):
+    op: ClassVar[ArithmeticOp] = ArithmeticOp.POW
 
 
 @dataclass

--- a/pygeofilter/cql2.py
+++ b/pygeofilter/cql2.py
@@ -64,6 +64,9 @@ ARITHMETIC_MAP: Dict[str, Type[ast.Arithmetic]] = {
     "-": ast.Sub,
     "*": ast.Mul,
     "/": ast.Div,
+    "%": ast.Mod,
+    "div": ast.IntDiv,
+    "^": ast.Pow,
 }
 
 CONDITION_MAP: Dict[str, Type[ast.Node]] = {

--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -101,9 +101,14 @@
     | sum "+" product                                                       -> add
     | sum "-" product                                                       -> sub
 
-?product: atom
-        | product "*" atom                                                  -> mul
-        | product "/" atom                                                  -> div
+?product: power
+        | product "*" power                                                 -> mul
+        | product "/" power                                                 -> div
+        | product "%" power                                                  -> mod
+        | product _INTDIV power                                             -> intdiv
+
+?power: atom
+      | atom "^" power                                                      -> pow
 
 ?atom: func
      | attribute
@@ -132,6 +137,8 @@ envelope: "ENVELOPE"i "(" number number number number ")"
 
 bbox: "BBOX"i "(" full_number "," full_number "," full_number "," full_number ")"
 
+PERCENT: "%"
+_INTDIV.1: /div/i
 BOOLEAN.2: ( "TRUE"i | "FALSE"i)
 
 DOUBLE_QUOTED: "\"" /.*?/ "\""

--- a/pygeofilter/parsers/cql2_text/parser.py
+++ b/pygeofilter/parsers/cql2_text/parser.py
@@ -163,6 +163,15 @@ class CQLTransformer(WKTTransformer, ISO8601Transformer):
     def div(self, lhs, rhs):
         return ast.Div(lhs, rhs)
 
+    def mod(self, lhs, rhs):
+        return ast.Mod(lhs, rhs)
+
+    def intdiv(self, lhs, rhs):
+        return ast.IntDiv(lhs, rhs)
+
+    def pow(self, lhs, rhs):
+        return ast.Pow(lhs, rhs)
+
     def neg(self, value):
         return -value
 

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -477,3 +477,23 @@ def test_not_eq():
     assert result == ast.Not(
         ast.Equal(ast.Attribute("attr"), 2)
     )
+
+
+def test_modulo():
+    result = parse("attr % 2 = 0")
+    assert result == ast.Equal(ast.Mod(ast.Attribute("attr"), 2), 0)
+
+
+def test_integer_division():
+    result = parse("attr div 2 = 1")
+    assert result == ast.Equal(ast.IntDiv(ast.Attribute("attr"), 2), 1)
+
+
+def test_power():
+    result = parse("attr ^ 2 = 4")
+    assert result == ast.Equal(ast.Pow(ast.Attribute("attr"), 2), 4)
+
+
+def test_power_right_associative():
+    result = parse("attr ^ 2 ^ 3 = 256")
+    assert result == ast.Equal(ast.Pow(ast.Attribute("attr"), ast.Pow(2, 3)), 256)


### PR DESCRIPTION
Implements three CQL2 arithmetic operators missing from the text parser:

- Modulo (%): e.g. 'attr % 2 = 0'
- Integer division (div): e.g. 'attr div 2 = 1'
- Power (^): e.g. 'attr ^ 2 = 4' (right-associative)

Changes span all layers:
- ast.py: adds ArithmeticOp.MOD/INTDIV/POW enums and Mod/IntDiv/Pow dataclasses
- cql2.py: extends ARITHMETIC_MAP with the three new operators
- grammar.lark: introduces a 'power' precedence level above 'product' for right-associative exponentiation; adds mod and intdiv production rules; uses named filter terminals (_PERCENT, _INTDIV) so they don't bleed into transformer callbacks
- parser.py: adds mod(), intdiv(), and pow() transformer methods
- tests: adds test_modulo, test_integer_division, test_power