### PR TITLE
fix(cql2): CQL2 Core conformance fixes

### DIFF
--- a/pygeofilter/backends/cql2_json/evaluate.py
+++ b/pygeofilter/backends/cql2_json/evaluate.py
@@ -103,13 +103,21 @@ class CQL2Evaluator(Evaluator):
     def interval(self, node: values.Interval, start, end):
         return {"interval": [start, end]}
 
-    @handle(datetime)
-    def datetime(self, node: ast.Attribute):
-        return {"timestamp": node.name}
-
     @handle(*values.LITERALS)
     def literal(self, node):
         return node
+
+    @handle(date)
+    def date_(self, node: date):
+        return {"date": node.isoformat()}
+
+    @handle(datetime)
+    def datetime_(self, node: datetime):
+        if node.microsecond:
+            ts = node.strftime("%Y-%m-%dT%H:%M:%S.") + f"{node.microsecond:06d}Z"
+        else:
+            ts = node.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return {"timestamp": ts}
 
     @handle(values.Geometry)
     def geometry(self, node: values.Geometry):

--- a/pygeofilter/parsers/cql2_text/grammar.lark
+++ b/pygeofilter/parsers/cql2_text/grammar.lark
@@ -143,7 +143,7 @@ DATETIME: /[0-9]{4}-?[0-1][0-9]-?[0-3][0-9][T ][0-2][0-9]:?[0-5][0-9]:?[0-5][0-9
 ?interval: "INTERVAL" "("  "'" DATETIME "'" "," "'" DATETIME "'" ")"
 ?date: "DATE" "(" "'" DATE "'" ")"
 
-attribute: /[a-zA-Z][a-zA-Z_:0-9.]+/
+attribute: /[a-zA-Z][a-zA-Z_:0-9.]*/
          | DOUBLE_QUOTED
 
 

--- a/pygeofilter/parsers/wkt.py
+++ b/pygeofilter/parsers/wkt.py
@@ -31,7 +31,6 @@ from lark import Transformer, v_args
 @v_args(meta=False, inline=True)
 class WKTTransformer(Transformer):
     def wkt__geometry_with_srid(self, srid, geometry):
-        print(srid, geometry)
         geometry["crs"] = {
             "type": "name",
             "properties": {"name": f"urn:ogc:def:crs:EPSG::{srid}"},
@@ -66,7 +65,6 @@ class WKTTransformer(Transformer):
         }
 
     def wkt__multipoint_2(self, *coordinates):
-        print(coordinates)
         return {
             "type": "MultiPoint",
             "coordinates": coordinates,

--- a/tests/parsers/cql2_json/test_parser.py
+++ b/tests/parsers/cql2_json/test_parser.py
@@ -32,6 +32,7 @@ from dateparser.timezone_parser import StaticTzInfo
 from pygeoif import geometry
 
 from pygeofilter import ast, values
+from pygeofilter.backends.cql2_json.evaluate import to_cql2
 from pygeofilter.parsers.cql2_json import parse
 
 
@@ -717,3 +718,18 @@ def test_function_attr_string_arg():
             ],
         ),
     )
+
+
+def test_encode_date():
+    node = ast.Equal(ast.Attribute("attr"), date(2000, 1, 1))
+    result = json.loads(to_cql2(node))
+    assert result["args"][1] == {"date": "2000-01-01"}
+
+
+def test_encode_timestamp():
+    node = ast.Equal(
+        ast.Attribute("attr"),
+        datetime(2000, 1, 1, 0, 0, 0, tzinfo=StaticTzInfo("Z", timedelta(0))),
+    )
+    result = json.loads(to_cql2(node))
+    assert result["args"][1] == {"timestamp": "2000-01-01T00:00:00Z"}

--- a/tests/parsers/cql2_text/test_parser.py
+++ b/tests/parsers/cql2_text/test_parser.py
@@ -477,3 +477,4 @@ def test_not_eq():
     assert result == ast.Not(
         ast.Equal(ast.Attribute("attr"), 2)
     )
+


### PR DESCRIPTION
Align the CQL2 Core conformance class with the OGC 21-065r2 spec.

## Changes

- **Property names**: Allow single-character identifiers (regex `+` → `*`)
- **JSON encoder**: Fix date/datetime serialization to use spec-required wrapper objects (`{"date": "..."}`, `{"timestamp": "...Z"}`) instead of bare strings. The existing `@handle(datetime)` was dead code (overridden by `literal` handler via metaclass ordering). Added proper handlers after `literal` so they take priority.
- **Timestamp format**: Use `Z` suffix per spec, not `+00:00`
- **Debug cleanup**: Remove leftover `print()` statements in `wkt.py`

## Spec reference

[OGC 21-065r2 §6.3.1](https://docs.ogc.org/is/21-065r2/21-065r2.html#scalar-data-types)