### PR TITLE
feat(cql2-json): support CQL2 spec function format in parser and encoder

### DIFF
--- a/pygeofilter/backends/cql2_json/evaluate.py
+++ b/pygeofilter/backends/cql2_json/evaluate.py
@@ -82,14 +82,7 @@ class CQL2Evaluator(Evaluator):
 
     @handle(ast.Function)
     def function(self, node, *args):
-        name = node.name.lower()
-        if name == "lower":
-            ret = {"lower": args[0]}
-        elif name == "upper":
-            ret = {"upper": args[0]}
-        else:
-            ret = {"function": name, "args": [*args]}
-        return ret
+        return {"op": node.name, "args": [*args]}
 
     @handle(ast.In)
     def in_(self, node, lhs, *options):

--- a/pygeofilter/parsers/cql2_json/parser.py
+++ b/pygeofilter/parsers/cql2_json/parser.py
@@ -165,6 +165,12 @@ def walk_cql_json(node: JsonType):  # noqa: C901
             args = [cast(ast.Node, walk_cql_json(arg)) for arg in args]
             return BINARY_OP_PREDICATES_MAP[op](*args)
 
+        else:
+            return ast.Function(
+                op,
+                [walk_cql_json(arg) for arg in args],
+            )
+
     raise ValueError(f"Unable to parse expression node {node!r}")
 
 

--- a/tests/parsers/cql2_json/test_parser.py
+++ b/tests/parsers/cql2_json/test_parser.py
@@ -32,6 +32,7 @@ from dateparser.timezone_parser import StaticTzInfo
 from pygeoif import geometry
 
 from pygeofilter import ast, values
+from pygeofilter.backends.cql2_json.evaluate import CQL2Evaluator
 from pygeofilter.parsers.cql2_json import parse
 
 
@@ -717,3 +718,25 @@ def test_function_attr_string_arg():
             ],
         ),
     )
+
+
+def test_function_spec_format():
+    """Parse spec-format function: {"op": "my_func", "args": [...]}"""
+    result = parse({"op": "my_func", "args": [{"property": "attr"}, 42]})
+    assert result == ast.Function("my_func", [ast.Attribute("attr"), 42])
+
+
+def test_function_old_format_still_works():
+    """Parse old format: {"function": {"name": "...", "arguments": [...]}}"""
+    result = parse(
+        {"function": {"name": "my_func", "arguments": [{"property": "attr"}]}}
+    )
+    assert result == ast.Function("my_func", [ast.Attribute("attr")])
+
+
+def test_function_encode_spec_format():
+    """Encode Function node to spec format: {"op": ..., "args": [...]}"""
+    evaluator = CQL2Evaluator(None, None)
+    node = ast.Function("my_func", [ast.Attribute("attr")])
+    result = evaluator.evaluate(node)
+    assert result == {"op": "my_func", "args": [{"property": "attr"}]}


### PR DESCRIPTION
Align the CQL2 Functions conformance class with the OGC 21-065r2 spec.

## Changes

- **JSON parser**: Unknown `op` values are now treated as function calls (`ast.Function`), supporting the spec's `{"op": "funcName", "args": [...]}` format. The old `{"function": {"name": "...", "arguments": [...]}}` format is preserved for backward compatibility.
- **JSON encoder**: Functions now emit `{"op": name, "args": [...]}` per spec, replacing the non-standard `{"function": name, "args": [...]}` and `{"lower": ...}`/`{"upper": ...}` formats.

## Spec reference

[OGC 21-065r2 §6.11](https://docs.ogc.org/is/21-065r2/21-065r2.html#functions)
JSON schema: `functionRef` requires `op` and `args`, where `op` is not a reserved operator name.