### PR TITLE
feat: added s_dwithin predicate

### DIFF
--- a/pygeofilter/cql2.py
+++ b/pygeofilter/cql2.py
@@ -32,6 +32,7 @@ SPATIAL_PREDICATES_MAP: Dict[str, Type[ast.SpatialComparisonPredicate]] = {
     "s_overlaps": ast.GeometryOverlaps,
     "s_crosses": ast.GeometryCrosses,
     "s_contains": ast.GeometryContains,
+    "s_dwithin": ast.DistanceWithin,
 }
 
 TEMPORAL_PREDICATES_MAP: Dict[str, Type[ast.TemporalPredicate]] = {


### PR DESCRIPTION
Adds support for `s_dwithin` predicate to query GeoJSON records whose `feature.geometry` is within a given distance from a specified point.

Here :arrow_right:  [pygeoapi/pull/2403](https://github.com/geopython/pygeoapi/pull/2403) is a link to  corresponding PR that modifies the Mongo provider in [pygeoapi](https://github.com/geopython/pygeoapi). Our goal is to enable queries like the one below:

```json
{
    "filter-lang": "cql2-json",
    "filter": {
        "op": "s_dwithin",
        "args": [
            {"property": "feature.geometry"},
            {
                "type": "Point",
                "coordinates": [13.0, 65.0]
            },
            250000,
            "meters"
        ]
    }
}

```
Thanks to @Jacob7052 for the implementation :sunglasses: 