### PR TITLE
feat: FES backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ pygeofilter is a pure Python parser implementation of OGC filtering standards
     * [CQL as defined in CSW 2.0](https://portal.ogc.org/files/?artifact_id=20555)
     * [CQL JSON as defined in OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)](https://portal.ogc.org/files/96288#cql-json-schema)
     * [JSON Filter Expressions (JFE)](https://github.com/tschaub/ogcapi-features/tree/json-array-expression/extensions/cql/jfe)
-    * Soon:
-        * [CQL Text as defined in OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)](https://portal.ogc.org/files/96288#cql-bnf)
-        * [FES](http://docs.opengeospatial.org/is/09-026r2/09-026r2.html)
+    * [CQL Text as defined in OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)](https://portal.ogc.org/files/96288#cql-bnf)
+    * [FES](http://docs.opengeospatial.org/is/09-026r2/09-026r2.html) (OGC filter encoding standard v1.1 & v2.0)
 * Several backends included
     * [Django](https://www.djangoproject.com/)
     * [SQLAlchemy](https://www.sqlalchemy.org/)
     * [(Geo)Pandas](https://pandas.pydata.org/)
+    * Apchae Solr
+    * Elasticsearch
+    * OpenSearch
+    * [CQL2 JSON](https://portal.ogc.org/files/96288#cql-json-schema)
+    * [FES](https://www.ogc.org/standards/filter/) (OGC filter encoding standard v.1.1)
     * Native Python objects
 
 

--- a/pygeofilter/backends/fes/__init__.py
+++ b/pygeofilter/backends/fes/__init__.py
@@ -1,0 +1,3 @@
+from .evaluate import to_lxml_etree, to_xml_str
+
+__all__ = ["to_xml_str", "to_lxml_etree"]

--- a/pygeofilter/backends/fes/evaluate.py
+++ b/pygeofilter/backends/fes/evaluate.py
@@ -1,0 +1,306 @@
+# ------------------------------------------------------------------------------
+#
+# Project: pygeofilter <https://github.com/geopython/pygeofilter>
+# Authors: Fabian Schindler <fabian.schindler@eox.at>
+# Johannes Eberenz <johannes.eberenz@alliander.com>
+#
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021 geopython
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ------------------------------------------------------------------------------
+
+from typing import Literal
+
+from lxml.etree import Element, tostring
+from pygml import v32
+
+from pygeofilter import ast, values
+from pygeofilter.backends.evaluator import Evaluator, handle
+
+FES20_URI = "http://www.opengis.net/fes/2.0"
+XSD_URI = "http://www.w3.org/2001/XMLSchema-datatypes"
+FES10_URI = "http://www.opengis.net/ogc"
+GML_URI = "http://www.opengis.net/gml"
+FES_VERSION = Literal["v1.1"]
+
+COMPARISON_OP_MAP = {
+    ast.ComparisonOp.EQ: "PropertyIsEqualTo",
+    ast.ComparisonOp.NE: "PropertyIsNotEqualTo",
+    ast.ComparisonOp.LT: "PropertyIsLessThan",
+    ast.ComparisonOp.LE: "PropertyIsLessThanOrEqualTo",
+    ast.ComparisonOp.GT: "PropertyIsGreaterThan",
+    ast.ComparisonOp.GE: "PropertyIsGreaterThanOrEqualTo",
+}
+
+
+ARITHMETIC_OP_MAP = {
+    ast.ArithmeticOp.ADD: "Add",
+    ast.ArithmeticOp.SUB: "Sub",
+    ast.ArithmeticOp.MUL: "Mul",
+    ast.ArithmeticOp.DIV: "Div",
+}
+
+SPATIAL_COMPARISON_OP_MAP = {
+    ast.SpatialComparisonOp.INTERSECTS: "Intersects",
+    ast.SpatialComparisonOp.DISJOINT: "Disjoint",
+    ast.SpatialComparisonOp.CONTAINS: "Contains",
+    ast.SpatialComparisonOp.WITHIN: "Within",
+    ast.SpatialComparisonOp.TOUCHES: "Touches",
+    ast.SpatialComparisonOp.CROSSES: "Crosses",
+    ast.SpatialComparisonOp.OVERLAPS: "Overlaps",
+    ast.SpatialComparisonOp.EQUALS: "Equals",
+}
+
+SPATIAL_DISTANCE_OP_MAP = {
+    ast.SpatialDistanceOp.DWITHIN: "Dwithin",
+    ast.SpatialDistanceOp.BEYOND: "Beyond",
+}
+
+
+class FESEvaluator(Evaluator):
+    def __init__(
+        self,
+        namespace: str,
+        fes_version: FES_VERSION = "v1.1",
+        gml_identifier: str | None = None,
+    ):
+        if fes_version != "v1.1":
+            raise (NotImplementedError("Only FES v1.1 is supported"))
+        self.ns = namespace
+        if namespace in ("", "{}"):
+            self.gml32_encoder = v32.GML3Encoder(
+                namespace="", nsmap=None, id_required=False
+            )
+        else:
+
+            self.gml32_encoder = v32.GML3Encoder(
+                namespace=v32.NAMESPACE, nsmap=v32.NSMAP, id_required=False
+            )
+        self.gml_identifier = gml_identifier
+
+    def negate_if_not(self, node, el) -> Element:
+        if node.not_:
+            return self.not_(None, el)
+        return el
+
+    @handle(ast.Not)
+    def not_(self, node, sub):
+        el = Element(self.ns + "Not")
+        el.append(sub)
+        return el
+
+    @handle(ast.And, ast.Or)
+    def combination(self, node, lhs, rhs):
+        el = Element(self.ns + node.op.value.title())
+        el.append(lhs)
+        el.append(rhs)
+        return el
+
+    @handle(ast.Comparison, subclasses=True)
+    def comparison(self, node, lhs, rhs):
+        el = Element(self.ns + COMPARISON_OP_MAP[node.op])
+        el.append(lhs)
+        el.append(rhs)
+        return el
+
+    @handle(ast.Between)
+    def between(self, node, lhs, low, high):
+        el = Element(self.ns + "PropertyIsBetween")
+        low_el = Element(self.ns + "LowerBoundary")
+        low_el.append(low)
+        high_el = Element(self.ns + "UpperBoundary")
+        high_el.append(high)
+        el.append(lhs)
+        el.append(low_el)
+        el.append(high_el)
+        return self.negate_if_not(node, el)
+
+    @handle(ast.Like)
+    def like(self, node, lhs):
+        el = Element(self.ns + "PropertyIsLike")
+        el.append(lhs)
+        # ast.
+        el.append(self.literal(node.pattern))
+        if node.wildcard:
+            el.attrib["wildCard"] = node.wildcard
+        if node.singlechar:
+            el.attrib["singleChar"] = node.singlechar
+        if node.escapechar:
+            el.attrib["escapeChar"] = node.escapechar
+        el.attrib["matchCase"] = str(not node.nocase).lower()
+
+        return self.negate_if_not(node, el)
+
+    @handle(ast.IsNull)
+    def null(self, node, lhs):
+        el = Element(self.ns + "PropertyIsNull")
+        el.append(lhs)
+        return self.negate_if_not(node, el)
+
+    @handle(ast.SpatialComparisonPredicate, subclasses=True)
+    def spatial_operation(self, node, lhs, rhs):
+        op = SPATIAL_COMPARISON_OP_MAP[node.op]
+        el = Element(self.ns + op)
+        el.append(lhs)
+        el.append(rhs)
+        return el
+
+    @handle(ast.BBox)
+    def bbox(self, node, lhs):
+        el = Element(self.ns + "BBOX")
+        if lhs is not None:
+            el.append(lhs)
+        envelope_el = self.envelope(
+            ast.values.Envelope(node.minx, node.maxx, node.miny, node.maxy)
+        )
+        if node.crs is not None:
+            envelope_el.attrib["srsName"] = node.crs
+        el.append(envelope_el)
+        return el
+
+    @handle(ast.SpatialDistancePredicate, subclasses=True)
+    def dwithin(self, node, lhs, rhs):
+        op = SPATIAL_DISTANCE_OP_MAP[node.op]
+        el = Element(self.ns + op)
+        el.append(lhs)
+        el.append(rhs)
+        dist_el = Element(self.ns + "Distance")
+        dist_el.text = str(node.distance)
+        dist_el.attrib["uom"] = node.units
+        el.append(dist_el)
+        return el
+
+    @handle(ast.Arithmetic, subclasses=True)
+    def arithmetic(self, node: ast.Arithmetic, lhs, rhs):
+        op = ARITHMETIC_OP_MAP[node.op]
+        el = Element(self.ns + op)
+        el.append(lhs)
+        el.append(rhs)
+        return el
+
+    @handle(ast.Function)
+    def function(self, node, *arguments):
+        el = Element(self.ns + "Function")
+        el.attrib["name"] = node.name
+        for arg in arguments:
+            el.append(arg)
+        return el
+
+    @handle(ast.Attribute)
+    def attribute(self, node: ast.Attribute):
+        el = Element(self.ns + "PropertyName")
+        el.text = node.name
+        return el
+
+    @handle(*values.LITERALS)
+    def literal(self, node):
+        el = Element(self.ns + "Literal")
+        el.text = str(node)
+        if self.ns != "":
+            match node:
+                case str():
+                    el.attrib["type"] = "xsd:string"
+                case int():
+                    el.attrib["type"] = "xsd:int"
+                case float():
+                    el.attrib["type"] = "xsd:double"
+                case bool():
+                    el.attrib["type"] = "xsd:boolean"
+                    el.text = str(node).lower()
+        return el
+
+    @handle(values.Geometry)
+    def geometry(self, node: values.Geometry):
+        gml = self.gml32_encoder.encode(
+            geometry=node.geometry, identifier=self.gml_identifier
+        )
+        if "srsName" in gml.attrib and "crs" not in node.geometry:
+            gml.attrib.pop(
+                "srsName"
+            )  # remove the default CRS, assumed by pygml
+        return gml
+
+    @handle(values.Envelope)
+    def envelope(self, node: values.Envelope):
+        """
+        Envelope values are converted to an WKT ENVELOPE for Solr.
+
+        If min_x > max_x, solr assume dateline crossing.
+        """
+        ns = f"{{{self.gml32_encoder.namespace}}}"
+        el = Element(ns + "Envelope", nsmap=self.gml32_encoder.nsmap)
+        lc_el = Element(self.ns + "lowerCorner")
+        lc_el.text = f"{node.x1} {node.y1}"
+        uc_el = Element(self.ns + "upperCorner")
+        uc_el.text = f"{node.x2} {node.y2}"
+        el.append(lc_el)
+        el.append(uc_el)
+        return el
+
+    # @handle(ast.In)
+    # def in_(self, node, lhs, *options):
+    #     raise NotImplementedError("'In' comparison is not supported by FES v1.1")
+
+
+def to_lxml_etree(
+    root,
+    namespaces=True,
+    fes_version: FES_VERSION = "v1.1",
+    gml_identifier: str | None = None,
+):
+    """Converts to OGC Feature encoding standard (FES) lxml elememt tree.
+    Only FES v1.1 is supported."""
+    if namespaces:
+        nsmap = {"ogc": FES10_URI, "xsd": XSD_URI}
+        fes_ns = f"{{{FES10_URI}}}"
+        filter_el = Element(fes_ns + "Filter", nsmap=nsmap)
+    else:
+        fes_ns = ""
+        filter_el = Element("Filter")
+    filter_el.append(
+        FESEvaluator(namespace=fes_ns, gml_identifier=gml_identifier).evaluate(
+            node=root
+        )
+    )
+    return filter_el
+
+
+def to_xml_str(
+    root,
+    pretty_print: bool = False,
+    namespaces: bool = True,
+    fes_version: FES_VERSION = "v1.1",
+    gml_identifier: str | None = None,
+) -> str:
+    """Converts to OGC Feature encoding standard (FES) XML string.
+    Keyword arguments:
+    pretty_print -- format output (default False)
+    namspaces -- add XML namespaces (default True)
+    fes_version -- Only FES v1.1 is supported (default v1.1)
+    gml_identifier -- prefix for id attribute of geometry tags (default None)
+    """
+    filter_el = to_lxml_etree(
+        root,
+        namespaces=namespaces,
+        fes_version=fes_version,
+        gml_identifier=gml_identifier,
+    )
+    xml_str = tostring(filter_el, encoding="unicode", pretty_print=pretty_print)
+    return xml_str

--- a/tests/backends/fes/test_fes_v11.py
+++ b/tests/backends/fes/test_fes_v11.py
@@ -1,0 +1,646 @@
+import re
+
+import pytest
+from lxml import etree
+
+from pygeofilter import ast, values
+from pygeofilter.backends.fes import to_lxml_etree, to_xml_str
+
+
+def strip_xml(xml_string: str) -> str:
+    """Remove newlines and whitespace"""
+    xml_string = re.sub(r"\s+<", "<", xml_string)
+    xml_string = re.sub(r"\n[ ]{2,}", " ", xml_string).strip()
+    return xml_string
+
+
+def test_strip_xml():
+    formatted_xml = """
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:Not>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>attr</ogc:PropertyName>
+          <ogc:Literal type="xsd:string">value</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Not>
+    </ogc:Filter>
+    """
+    result = strip_xml(formatted_xml)
+    expected = (
+        '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"'
+        ' xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">'
+        "<ogc:Not><ogc:PropertyIsEqualTo><ogc:PropertyName>attr"
+        '</ogc:PropertyName><ogc:Literal type="xsd:string">'
+        "value</ogc:Literal></ogc:PropertyIsEqualTo>"
+        "</ogc:Not></ogc:Filter>"
+    )
+    assert result == expected
+
+
+def test_and():
+    # fmt: off
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:And>
+        <ogc:PropertyIsLessThan>
+          <ogc:PropertyName>attr</ogc:PropertyName>
+          <ogc:Literal type="xsd:int">30</ogc:Literal>
+        </ogc:PropertyIsLessThan>
+        <ogc:PropertyIsGreaterThan>
+          <ogc:PropertyName>attr</ogc:PropertyName>
+          <ogc:Literal type="xsd:int">10</ogc:Literal>
+        </ogc:PropertyIsGreaterThan>
+      </ogc:And>
+    </ogc:Filter>""")
+
+    result = to_xml_str(
+        ast.And(
+            ast.LessThan(
+                ast.Attribute("attr"),
+                30,
+            ),
+            ast.GreaterThan(
+                ast.Attribute("attr"),
+                10,
+            ),
+        )
+    )
+    assert result == expected_xml
+
+
+def test_or():
+    expected_xml = strip_xml("""<Filter>
+      <Or>
+        <PropertyIsLessThanOrEqualTo>
+        <PropertyName>attr</PropertyName>
+        <Literal>30.5</Literal>
+        </PropertyIsLessThanOrEqualTo>
+        <PropertyIsGreaterThanOrEqualTo>
+        <PropertyName>attr</PropertyName>
+        <Literal>10.5</Literal>
+        </PropertyIsGreaterThanOrEqualTo>
+      </Or>
+    </Filter>""")
+    result = to_xml_str(
+        ast.Or(
+            ast.LessEqual(
+                ast.Attribute("attr"),
+                30.5,
+            ),
+            ast.GreaterEqual(
+                ast.Attribute("attr"),
+                10.5,
+            ),
+        ),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_not():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:Not>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>attr</ogc:PropertyName>
+          <ogc:Literal type="xsd:string">value</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Not>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.Not(
+            ast.Equal(
+                ast.Attribute("attr"),
+                "value",
+            )
+        )
+    )
+    assert result == expected_xml
+
+
+def test_not_equal():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:PropertyIsNotEqualTo>
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <ogc:Literal type="xsd:string">value</ogc:Literal>
+      </ogc:PropertyIsNotEqualTo>
+    </ogc:Filter>""")
+    result = to_xml_str(ast.NotEqual(ast.Attribute("attr"), "value"))
+    assert result == expected_xml
+
+
+def test_is_like():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:PropertyIsLike
+          wildCard="%"
+          singleChar="."
+          escapeChar="\\"
+          matchCase="true">
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <ogc:Literal type="xsd:string">some%</ogc:Literal>
+      </ogc:PropertyIsLike>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.Like(
+            ast.Attribute("attr"),
+            "some%",
+            nocase=False,
+            not_=False,
+            wildcard="%",
+            singlechar=".",
+            escapechar="\\",
+        )
+    )
+    assert result == expected_xml
+
+    # case insensitive
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:PropertyIsLike
+          wildCard="%"
+          singleChar="."
+          escapeChar="\\"
+          matchCase="false">
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <ogc:Literal type="xsd:string">some%</ogc:Literal>
+      </ogc:PropertyIsLike>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.Like(
+            ast.Attribute("attr"),
+            "some%",
+            nocase=True,
+            not_=False,
+            wildcard="%",
+            singlechar=".",
+            escapechar="\\",
+        )
+    )
+    assert result == expected_xml
+
+
+def test_is_null():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:PropertyIsNull>
+        <ogc:PropertyName>attr</ogc:PropertyName>
+      </ogc:PropertyIsNull>
+    </ogc:Filter>""")
+    result = to_xml_str(ast.IsNull(ast.Attribute("attr"), not_=False))
+    assert result == expected_xml
+
+    # Not
+    expected_xml = "<Filter><Not><PropertyIsNull><PropertyName>attr</PropertyName></PropertyIsNull></Not></Filter>"  # noqa
+    result = to_xml_str(
+        ast.IsNull(ast.Attribute("attr"), not_=True), namespaces=False
+    )
+    assert result == expected_xml
+
+
+def test_is_between():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:PropertyIsBetween>
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <ogc:LowerBoundary>
+          <ogc:Literal type="xsd:double">10.5</ogc:Literal>
+        </ogc:LowerBoundary>
+        <ogc:UpperBoundary>
+          <ogc:Literal type="xsd:double">11.5</ogc:Literal>
+        </ogc:UpperBoundary>
+      </ogc:PropertyIsBetween>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.Between(ast.Attribute("attr"), 10.5, 11.5, not_=False)
+    )
+    assert result == expected_xml
+
+
+def test_geom_equals():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:Equals>
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <gml:Point xmlns:gml="http://www.opengis.net/gml/3.2"
+                  srsName="http://www.opengis.net/def/crs/epsg/0/4326">
+          <gml:pos>1.0 1.0</gml:pos>
+        </gml:Point>
+      </ogc:Equals>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.GeometryEquals(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "Point",
+                    "coordinates": (1.0, 1.0),
+                    "crs": {
+                        "type": "name",
+                        "properties": {
+                            "name": "http://www.opengis.net/def/crs/epsg/0/4326"
+                        },
+                    },
+                }
+            ),
+        )
+    )
+    assert result == expected_xml
+
+
+def test_geom_disjoint():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:Disjoint>
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <gml:LineString xmlns:gml="http://www.opengis.net/gml/3.2">
+          <gml:posList>1.0 1.0 2.0 2.0</gml:posList>
+        </gml:LineString>
+      </ogc:Disjoint>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.GeometryDisjoint(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "LineString",
+                    "coordinates": [
+                        (1.0, 1.0),
+                        (2.0, 2.0),
+                    ],
+                }
+            ),
+        )
+    )
+    assert result == expected_xml
+
+
+def test_geom_touches():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:Touches>
+        <ogc:PropertyName>attr</ogc:PropertyName>
+        <gml:Polygon xmlns:gml="http://www.opengis.net/gml/3.2">
+            <gml:exterior>
+                <gml:LinearRing>
+                    <gml:posList>0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.0</gml:posList>
+                </gml:LinearRing>
+            </gml:exterior>
+            <gml:interior>
+                <gml:LinearRing>
+                    <gml:posList>0.2 0.2 0.5 0.2 0.2 0.5 0.2 0.2</gml:posList>
+                </gml:LinearRing>
+            </gml:interior>
+        </gml:Polygon>
+      </ogc:Touches>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.GeometryTouches(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (0.0, 0.0)],
+                        [(0.2, 0.2), (0.5, 0.2), (0.2, 0.5), (0.2, 0.2)],
+                    ],
+                }
+            ),
+        )
+    )
+    assert result == expected_xml
+
+
+def test_geom_within():
+    expected_xml = strip_xml("""<Filter>
+    <Within>
+        <PropertyName>attr</PropertyName>
+        <Polygon>
+        <exterior>
+            <LinearRing>
+            <posList>0.0 1.0 0.0 3.0 2.0 3.0 2.0 1.0 0.0 1.0</posList>
+            </LinearRing>
+        </exterior>
+        </Polygon>
+    </Within>
+    </Filter>""")
+    result = to_xml_str(
+        ast.GeometryWithin(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            (0.0, 1.0),
+                            (0.0, 3.0),
+                            (2.0, 3.0),
+                            (2.0, 1.0),
+                            (0.0, 1.0),
+                        ],
+                    ],
+                }
+            ),
+        ),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_geom_overlaps():
+    expected_xml = strip_xml("""<Filter>
+      <Overlaps>
+        <PropertyName>attr</PropertyName>
+        <MultiSurface id="id">
+          <surfaceMembers>
+            <Polygon id="id_0">
+              <exterior>
+                <LinearRing>
+                  <posList>0.0 0.0 1.0 0.0 0.0 1.0 0.0 0.0</posList>
+                </LinearRing>
+              </exterior>
+              <interior>
+                <LinearRing>
+                  <posList>0.2 0.2 0.5 0.2 0.2 0.5 0.2 0.2</posList>
+                </LinearRing>
+              </interior>
+            </Polygon>
+            <Polygon id="id_1">
+              <exterior>
+                <LinearRing>
+                  <posList>10.0 10.0 11.0 10.0 10.0 11.0 10.0 10.0</posList>
+                </LinearRing>
+              </exterior>
+              <interior>
+                <LinearRing>
+                  <posList>10.2 10.2 10.5 10.2 10.2 10.5 10.2 10.2</posList>
+                </LinearRing>
+              </interior>
+            </Polygon>
+          </surfaceMembers>
+        </MultiSurface>
+      </Overlaps>
+    </Filter>""")
+    result = to_xml_str(
+        ast.GeometryOverlaps(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [
+                            [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (0.0, 0.0)],
+                            [(0.2, 0.2), (0.5, 0.2), (0.2, 0.5), (0.2, 0.2)],
+                        ],
+                        [
+                            [
+                                (10.0, 10.0),
+                                (11.0, 10.0),
+                                (10.0, 11.0),
+                                (10.0, 10.0),
+                            ],
+                            [
+                                (10.2, 10.2),
+                                (10.5, 10.2),
+                                (10.2, 10.5),
+                                (10.2, 10.2),
+                            ],
+                        ],
+                    ],
+                }
+            ),
+        ),
+        namespaces=False,
+        gml_identifier="id",
+    )
+    assert result == expected_xml
+
+
+def test_geom_crosses():
+    expected_xml = strip_xml("""<Filter>
+      <Crosses>
+        <PropertyName>attr</PropertyName>
+        <LineString>
+          <posList>2.0 1.0 1.0 2.0</posList>
+        </LineString>
+      </Crosses>
+    </Filter>""")
+    result = to_xml_str(
+        ast.GeometryCrosses(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {"type": "LineString", "coordinates": [(2.0, 1.0), (1.0, 2.0)]}
+            ),
+        ),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_geom_intersects():
+    expected_xml = strip_xml("""<Filter>
+      <Intersects>
+        <PropertyName>attr</PropertyName>
+        <Polygon>
+          <exterior>
+            <LinearRing>
+              <posList>0.5 1.0 0.5 2.0 1.5 2.0 1.5 1.0 0.5 1.0</posList>
+            </LinearRing>
+          </exterior>
+        </Polygon>
+      </Intersects>
+    </Filter>""")
+    result = to_xml_str(
+        ast.GeometryIntersects(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "Polygon",
+                    "bbox": (0.5, 1.0, 1.5, 2.0),
+                    "coordinates": [
+                        [
+                            (0.5, 1.0),
+                            (0.5, 2.0),
+                            (1.5, 2.0),
+                            (1.5, 1.0),
+                            (0.5, 1.0),
+                        ]
+                    ],
+                }
+            ),
+        ),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_geom_bbox():
+    expected_xml = strip_xml("""<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema-datatypes">
+      <ogc:BBOX>
+        <ogc:PropertyName>geom_attr</ogc:PropertyName>
+        <gml:Envelope xmlns:gml="http://www.opengis.net/gml/3.2" srsName="epsg:4306">
+          <ogc:lowerCorner>13.0983 31.5899</ogc:lowerCorner>
+          <ogc:upperCorner>35.5472 42.8143</ogc:upperCorner>
+        </gml:Envelope>
+      </ogc:BBOX>
+    </ogc:Filter>""")
+    result = to_xml_str(
+        ast.BBox(
+            lhs=ast.Attribute("geom_attr"),
+            minx=13.0983,
+            miny=31.5899,
+            maxx=35.5472,
+            maxy=42.8143,
+            crs="epsg:4306",
+        ), namespaces=True
+    )
+    assert result == expected_xml
+
+
+    # no namespaces
+    expected_xml = strip_xml("""<Filter>
+      <BBOX>
+        <PropertyName>geom_attr</PropertyName>
+        <Envelope srsName="epsg:4306">
+          <lowerCorner>13.0983 31.5899</lowerCorner>
+          <upperCorner>35.5472 42.8143</upperCorner>
+        </Envelope>
+      </BBOX>
+    </Filter>""")
+    result = to_xml_str(
+        ast.BBox(
+            lhs=ast.Attribute("geom_attr"),
+            minx=13.0983,
+            miny=31.5899,
+            maxx=35.5472,
+            maxy=42.8143,
+            crs="epsg:4306",
+        ), namespaces=False
+    )
+    assert result == expected_xml
+
+def test_geom_contains():
+    expected_xml = strip_xml("""<Filter>
+      <Contains>
+        <PropertyName>attr</PropertyName>
+        <Polygon>
+          <exterior>
+            <LinearRing>
+              <posList>0.5 1.0 0.5 2.0 1.5 2.0 1.5 1.0 0.5 1.0</posList>
+            </LinearRing>
+          </exterior>
+        </Polygon>
+      </Contains>
+    </Filter>""")
+    result = to_xml_str(
+        ast.GeometryContains(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            (0.5, 1.0),
+                            (0.5, 2.0),
+                            (1.5, 2.0),
+                            (1.5, 1.0),
+                            (0.5, 1.0),
+                        ]
+                    ],
+                }
+            ),
+        ),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_geom_dwithin():
+    expected_xml = strip_xml("""<Filter>
+      <Dwithin>
+        <PropertyName>attr</PropertyName>
+        <Point srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
+          <pos>142898.9 473511.1</pos>
+        </Point>
+        <Distance uom="km">10</Distance>
+      </Dwithin>
+    </Filter>""")
+    result = to_xml_str(
+        ast.DistanceWithin(
+            ast.Attribute("attr"),
+            values.Geometry(
+                {
+                    "type": "Point",
+                    "coordinates": (142898.9, 473511.1),
+                    "crs": {
+                        "type": "name",
+                        "properties": {
+                            "name": "http://www.opengis.net/def/crs/EPSG/0/28992"
+                        },
+                    },
+                }
+            ),
+            distance=10,
+            units="km",
+        ),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_aritmethic():
+    expected_xml = strip_xml("""<Filter>
+      <PropertyIsEqualTo>
+        <PropertyName>PROPA</PropertyName>
+        <Add>
+          <PropertyName>PROPB</PropertyName>
+          <Literal>100</Literal>
+        </Add>
+      </PropertyIsEqualTo>
+    </Filter>""")
+    result = to_xml_str(
+        ast.Equal(ast.Attribute("PROPA"), ast.Add(ast.Attribute("PROPB"), 100)),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_function():
+    expected_xml = strip_xml("""<Filter>
+      <PropertyIsEqualTo>
+        <Function name="SIN">
+          <PropertyName>DISPERSION_ANGLE</PropertyName>
+        </Function>
+        <Literal>1</Literal>
+      </PropertyIsEqualTo>
+    </Filter>""")
+    result = to_xml_str(
+        ast.Equal(ast.Function("SIN", [ast.Attribute("DISPERSION_ANGLE")]), 1),
+        namespaces=False,
+    )
+    assert result == expected_xml
+
+
+def test_xml_tree():
+    xml_str = """<Filter>
+      <PropertyIsEqualTo>
+        <Function name="SIN">
+          <PropertyName>DISPERSION_ANGLE</PropertyName>
+        </Function>
+        <Literal>1</Literal>
+      </PropertyIsEqualTo>
+    </Filter>"""
+    result = to_lxml_etree(
+        ast.Equal(ast.Function("SIN", [ast.Attribute("DISPERSION_ANGLE")]), 1),
+        namespaces=False,
+    )
+    assert type(result) is etree._Element
+    assert etree.tostring(result, encoding="unicode") == strip_xml(xml_str)
+
+
+def test_v20():
+    with pytest.raises(NotImplementedError):
+        to_xml_str(None, fes_version="v2.0")  # type: ignore


### PR DESCRIPTION
- Only FES v1.1 supported
- All geometries cast to GML 3.2


Motivation: pygeofilter as middleware for MapServer WMS/WFS to offer CQL2 filters